### PR TITLE
Improved README to explain what EIPs are

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,1 +1,5 @@
 # Ergo Improvement Proposals
+
+Ergo Improvement Proposals (EIPs) specify and/or describe standards for the Ergo Platform, including core protocol specifications, client APIs, dApp/contract standards, and other such things.
+
+Please check out existing EIPs, such as [EIP-1](https://github.com/ergoplatform/eips/blob/master/eip-0001.md), to understand the general expectation of how EIPs are supposed to be formatted.


### PR DESCRIPTION
Empty README should have been addressed a while back. I added a basic explanation.