### PR TITLE
 EIP-0006: Informal Multi-Stage Contract Specification Format

### DIFF
--- a/eip-0006.md
+++ b/eip-0006.md
@@ -1,163 +1,259 @@
-# EIP-0006: Well-known Contracts 
+# EIP-0006: Informal Multi-Stage Contract Specification Format
 
-* Author: aslesarenko 
+* Author: Robert Kornacki
 * Status: Proposed
-* Created: 12-Apr-2020
+* Created: 21-Apr-2020
 * License: CC0
-* Forking: hard-fork needed 
+* Forking: No fork needed 
 
 ### Contents
 - [Background And Motivation](#background-and-motivation)
-- [Well-known Contract Format](#well-known-contract-format)
-- [Well-known Contracts List](#well-known-contracts-list)
-- [Implementation of The Standard](#implementation-of-the-standard)
-  - [Changes in Serialization](#changes-in-serialization)
-  - [Changes in Costing](#changes-in-costing)
+- [How Informal Multi-Stage Contract Specs Are Written](#How-Informal-Multi-Stage-Contract-Specs-Are-Written)
+- [Alternative Formatting](#Alternative-formatting)
+- [Example NFT Auction Contract](#example-nft-auction-contract)
+- [Conclusion](#Conclusion)
 
 ### Background And Motivation
 
-Ergo is a blockchain designed for long-term survivability, resilience to attacks and
-security. To facilitate these goals the following parameters of the network should be
-optimized:
-- Blockchain storage size on full nodes
-- Speed of Block Candidate assembly from pooled transactions
-- transaction validation speed (txs/sec) 
-- minimal network traffic required for a node to stay connected and keep the pace of the
-blockchain growth (obtaining new blocks, broadcasting new candidates)
-- Node memory footprint 
+[Multi-stage contracts](https://link.springer.com/chapter/10.1007/978-3-030-31500-9_16) are a fascinating tool for implementing complex protocols on a UTXO-based system. They allow for great expressiveness and are generally approachable due to the fact that different phases of a protocol are cleanly separated into their own sub-contracts.
 
-One of the opportunities to improve the network is to exploit the _stable_ nature of many
-useful contract templates (Here _stability_ means the new versions of the contracts are
-not created very often, if created at all):
-1) Ergo uses many contracts as part of its core protocol like
-`feeProposition`, `rewardOutputScript`, `foundationScript` etc. The contracts are fixed
-and are not supposed to be changed. 
-2) Many contracts such as those used in ErgoMix, DEX, Crowd Funding, etc. may become
-widely reusable. Many applications may be created on top of them. Such contracts have a
-natural tendency to be stable to keep backward compatibility with applications that use
-them.
-3) Stability of contracts also plays well with security. Intuitively, it feels very
-unsafe to send coins to an unknown contract. On the other hand, it is generally safe to
-send coins to the _well-known_ contracts, which have well described properties,
-verified by community experts and signed by network developers (or Foundation board
-members).
+With that said, multi-stage contracts are extremely nascent as a model. This means that though they may be simpler when compared to alternatives, complexity is still going to be present when dealing with protocols that require numerous stages. Furthermore, we could benefit from conveying to others how a protocol is supposed to be implemented and/or work without writing a single line of code.
 
-However, despite the actual stability of many contracts, in the Ergo Protocol v1 their
-copies have to be saved in thousands of transactions and UTXO boxes which they protect.
-This significantly increases the blockchain size and UTXO memory footprint. It also have
-significant computational overhead due to parsing and cost limit control.
+As such it would be quite handy to have a format to informally define specifications for our multi-stage contracts that is understandable, easily traversable, and can be used as a guide for eventually writing both the on-chain and off-chain code.
 
-This Ergo Improvement Proposal standardizes the protocol extension to factor those
-well-known contracts out of serializable boxes, transactions, blocks and finally out of the
-blockchain storage. It also allows to reduce validation time of both new block candidates
-and broadcasted blocks.
 
-### Well-known Contract Format
-Each _well-known contract_ must be specified and registered as it is described in this section and then
-added to the [list in the following section](#well-known-contracts-list).
 
-To specify a new well-known contract one needs:
+### How Informal Multi-Stage Contract Specs Are Written
 
-1) Obtain a the last registered well-known contract from [the list of well-known
-contracts](#well-known-contracts-list).
+Let's look at the markdown-based schema in it's entirety and drill down how it works below.
 
-1) Obtain `lastContractId` and the current counter value `C` from the most recent contract
-registration record.
+```md
+# Contract Name
+Contract preamble
 
-1) Describe the contract template according to [EIP-0005](eip-0005.md) and obtain its
-serialized bytes `contractBytes`. We impose an additional requirement that the number of
-segregated constants of the contract template is equal to the number of parameters. This
-is important to allow the same template (with exactly the same bytes) to be reused across
-many different ErgoTree instances of well-known contracts.
+## ToC
+1. [Bootstrap Stage](<#Bootstrap-Stage>)
+2. [X Stage](<#X-Stage>)
 
-1) Sign the "lastContractId|contractBytes" bytes with `Foundation Signature` (which can be
-a threshold `2-out-of-6` or similar signature) and obtain `signatureBytes`.
+## Bootstrap Stage
+Preamble of how the contract is bootstrapped. 
 
-1) Add a new contract registration data as a sub-section of the [next
-section](#well-known-contracts-list) using the data described in th
+### List Of Paths
+- [Y Path](<#Y-Path>)
+ 
+### Y Path
+Preamble
 
-1) Obtain a new `contractId` bytes by running `Blake2b256((C+1)|lastContractId|contractBytes|signatureBytes)`
+#### Inputs
+1. ...
+2. ...
+3. ...
 
-Column           | Value              | Description
------------------|--------------------|------------------
-`contractId`     | `contractId`       | The hash of the contract registration content 
-`contractCode`   | C + 1              | The next code of the contract
-`prevContractId` | `lastContractId`   | The hash of the previous registered contract 
-`contractBytes`  | `Base16` or `File` | Contract Template bytes according to [EIP-0005](eip-0005.md) 
-`contractSig`    | `Base16` or `File` | The `signatureBytes` as Base16
 
-### Well-known Contracts List
+#### Outputs
+1. ...
+2. ...
+3. ...
 
-Each well-known contract must be added here in a sub-section and described according to
-the [well-known contract format](#well-known-contract-format). Each contract refers to the
-previous contract using its id thus forming a chain of contract registrations. The
-consistency of the whole chain and signatures can be verified by the software implemening
-both [EIP-0005](eip-0005.md) and this standard.
 
-#### RewardOutputScript contract
+#### Leads To
+[X Stage](<#X-Stage>)
 
-```json
-{
-  "contractId": "2025692038620398",
-  "contractCode": 1,
-  "prevContractId": "",
-  "contractTemplate": {
-    "name": "RewardOutputScript",
-    "description": "holds mining rewards",
-    "constants": "0204a00b08cd0279be667ef9dcbbac55a06295ce870b07029bfcdb2dce28d959f2815b16f81798",
-    "template": "ea02d192a39a8cc7a70173007301",
-    "parameters": [
-       { 
-         "name": "delta",
-         "description": "spending delay",
-         "type": "04",
-         "placeholder": 0
-       }
-    ]
-  },
-  "contractSignature": "11010823470091823840001349712304860891123948601298723" 
-}
+---
+
+## X Stage
+Preamble
+
+### Hard-coded Values
+- ...
+
+### Registers
+- R4: ...
+- R5: ...
+
+
+### List Of Paths
+- [Y Path](<#Y-Path>)
+ 
+### Y Path
+Preamble
+
+#### Inputs
+1. ...
+2. ...
+3. ...
+
+
+#### Outputs
+1. ...
+2. ...
+3. ...
+
+
+#### Path Conditions
+1. ...
+2. ...
+
+
+#### Leads To
+`Hyperlinked name of next stage` OR `Exit`
+
+---
+
 ```
 
-### Implementation of The Standard
+As you can see above, each contract is made out of a number of **stages**. Each stage (except for the bootstrap stage) is a specific contract that the locks up tokens and data. Every stage has the ability to specify values which are hard-coded within the contract, and/or values which are stored in the registers.
 
-The extension is fully encapsulated (localized) in the implementation of ErgoTree and
-transparent to the rest of the protocol except cost estimation (see [sub-section
-below](#changes-in-costing)). The standard requires extending of the serialization format
-of ErgoTree.
+From each stage you have one or more **paths**, which are state transitions from the current stage to another (or to itself recursively). Each path specifies the required **inputs boxes**, **output boxes**, and **path conditions**. Path conditions are the logical checks which are encoded within the contract which must be met in order to allow for a state transition to occur and thus for said path to be taken.
 
-#### Changes in Serialization
+Finally, each path also **leads to** somewhere else. In other words, the state transition must move the tokens and data held under the current stage to another. Thus we specify the next stage that a path leads to or `Exit`. Exit signifies that this is an **exit path** meaning that the multi-stage contract is finished executing and the locked data/tokens can be arbitrarily spent (thus exit the multi-stage contract).
 
-The `Bit 5` reserved in the `header` of ErgoTree (which is `0` by default, see
-[ErgoTree](https://ergoplatform.org/docs/ErgoTree.pdf) section _ErgoTree serialization_)
-can be set to `1` to indicate the contract is _well-known_. When the `Bit 5`
-(`WellKnownContractBit`) is set the `root` slot contains the `contractCode` of one of the
-well-known contracts registered in the list above
+In the Bootstrap Stage there are no hard-coded values, registers, or path conditions because there is no contract yet at this point. Depending on the complexity of a protocol, it is possible for a multi-stage contract to have one or more bootstrap stages (bootstrapping different actors into different stages in the protocol).
 
-Slot           | Format      | #bytes   | Description
----------------|-------------|----------|-----
-_header_       | VLQ(UInt)   | [1, *]   | The header with `Bit 5` set to 1
-...            |             |          | other slots of ErgoTree
-root           | VLQ(UInt)   | [1, *]   | `contractCode` of a registered well-known contract
+Clearly writing out the inputs + outputs as well as the path conditions may feel a little verbose, however this is on purpose. One only needs to focus on the required inputs + outputs when writing off-chain code for creating a transaction for a given path. On the flip side, when writing code which will live on-chain (the contracts), one only needs to pay attention to the path conditions of a given stage.
 
-To deserialize the ErgoTree with `WellKnownContractBit == 1` every compliant protocol
-implementation should keep a mapping between contract codes and contract templates. When
-the `contractCode` is deserialized it can be used to lookup the contract template in the
-mapping. Thus obtained contract template is then used as the `root` expression tree of the
-ErgoTree instance. The `contractCode` value is also stored in the ErgoTree instance.
+Every stage, path, and the contract itself has room for a preamble/explanation of what is going on in the given section. This allows for the spec writer to add extra comments and/or make clarifications so that it is painfully clear how the multi-stage contract is supposed to work when sharing with others.
 
-Note, that the same well-known contract template instance can be shared across all
-ErgoTree instances, since the parameters are all segregated. This not only completely
-avoids the deserialization of well-known templates, but also reduces memory footprint (and
-GC pressure) during massive transaction processing.
+Using markdown we get the benefit of being able to hyperlink the stages in the ToC, the paths for each stage, and where each path leads to. This provides us with a reasonable interface for going through informal specifications and gaining an understanding of how the different stages are inter-linked. With both an eagle's eye view using the ToC as well as with a targeted/sequential view via following path hyperlinks, we have the ability to dig into how the parts and the whole of any given informal specification work.
 
-#### Changes in Costing
 
-Cost estimation can be optimized for some of the well-known contracts by associating a
-fixed `cost` value with each contract. This association can be stored as `wellKnownCosts`
-data in the extensions section of each Block and updated by miners via voting.
+### Alternative Formatting
 
-When an input is protected by a well-known contract, then `wellKnownCosts` table can be looked
-up to quickly obtain script verification cost. This cost can be accumulated to the total
-block cost.
+If the list format is too crowded for inputs/outputs/conditions, the following format is available as well for more complicated contracts which have a lot of registers and/or tokens.
 
+```md
+#### Inputs 
+##### Input #1
+...
+##### Input #2
+...
+
+#### Outputs
+##### Ouput #1
+...
+##### Ouput #2
+...
+
+#### Path Conditions
+##### Condition 1
+...
+##### Condition 2
+...
+
+```
+
+This allows one to use lists within each given section, thereby allowing for much more room to go into detail about specifics. This can be useful for contracts which use several registers across several boxes in their path conditions for example.
+
+With all of that said, let's now look at an example informal specification which uses the above scheme/format to define an NFT auction contract.
+
+
+
+
+# Example NFT Auction Contract
+This contract allows a user to initiate an on-chain auction for a NFT/singleton token which accepts bids in Ergs. This informal specification is based off of the discussion/original design from [this Ergo Forum thread](https://www.ergoforum.org/t/auctions-on-ergo/122).
+
+
+## ToC
+1. [Bootstrap Stage](<#bootstrap-stage>)
+2. [Auction Stage](<#auction-stage>)
+
+
+## Bootstrap Stage
+
+This stage allows a user to initiate the auction. It requires that they provide their NFT and a box with Erg which represents the starting bid. There are no hard-coded values, registers, or path conditions because this is the bootstrap stage and thus there is no contract yet.
+
+### List Of Paths
+- [Initiate Auction Path](<#Initiate-Auction-Path>)
+
+
+### Initiate Auction Path
+
+#### Inputs
+1. Box which holds the NFT that is to be put up for auction.
+2. Box with Ergs equivalent to the starting bid price.
+
+
+#### Outputs
+1. A box locked under the Auction contract/stage that holds the NFT and Ergs from the inputs, which also stores the auction holder's public key in register R4.
+
+
+#### Leads To
+[Auction Stage](<#Auction-Stage>)
+
+---
+
+
+## Auction Stage
+In this stage the NFT is held up for auction and anyone who has enough Ergs can place a bid before the auction ends. All new bids must increment by at least 0.5 Erg.
+
+### Hard-coded Values
+- Auction holder's public key
+- Auction end block height
+
+### Registers
+- R4: The current highest bidder's public key
+
+### List Of Paths
+- [Bid Path](<#Bid-Path>)
+- [Conclude Auction Path](<#Conclude-Auction-Path>)
+
+
+### Bid Path
+This path recurses the box back into the Auction stage with the new Ergs held inside and the current winning bidder in R4 updated.
+
+#### Inputs
+1. The auction box.
+2. Box(es) owned by the bidder which has enough Ergs to total the previous bid + 0.5 Erg.
+
+
+#### Outputs
+1. A new box locked under the Auction contract again which has the new bidder's public key in R4, the NFT, and the Ergs for the bid.
+2. A box owned by the previous bidder which gives them back the Ergs which they bid.
+
+
+#### Path Conditions
+1. The current block height must be less than the auction end block height hard-coded into the contract.
+2. The first output box must be locked under the Auction contract and holds the bidder's public key in R4, the NFT, and Ergs totalling at least 0.5 Erg more than the previous bid.
+3. The second output box is owned by the previous bidder and has a total number of Ergs equal to their bid.
+
+
+#### Leads To
+[Auction Stage](<#Auction-Stage>)
+
+
+### Conclude Auction Path
+
+This path allows for the NFT and the funds to be redeemed to the auction winner and holder respectively once the auction finish height has been reached. If no one bid on the auction then the auction holder still has their public key in register R4, and therefore can redeem both their NFT and their Ergs to themselves.
+
+#### Inputs
+1. The auction box.
+
+
+#### Outputs
+1. A box owned by the address stored in R4 which holds the NFT.
+2. A box owned by the auction holder which receives all of the Ergs bid.
+
+
+#### Path Conditions
+1. The current block height must be grater than the auction end block height hard-coded into the contract.
+2. The first output box must hold the NFT and be owned by the pub key stored in R4.
+3. The second output box must hold all of the Ergs and be owned by the auction holder.
+
+
+#### Leads To
+Exit
+
+---
+
+
+### Conclusion
+
+The markdown-based schema outlined in this document provides the writer the feeling of freedom via easily changing whatever they've written as if it were an essay rather than the clunky feeling of writing compiled code (or a formal spec). 
+This flexibility is useful when figuring out how to implement a protocol which typically requires making edits often and moving fast as previous ideas become obsolete and/or are found to be broken.
+
+Once an informal specification has been finalized, it can be used as a clear guide for:
+1. Writing a formal specification.
+2. Implementing the contracts in ErgoScript.
+3. Designing the off-chain transaction logic.
+
+As such it is my contention that utilizing this informal specification format is important for the long-term success of contracts and dApps on the Ergo Platform.

--- a/eip-0006.md
+++ b/eip-0006.md
@@ -2,18 +2,17 @@
 
 * Author: aslesarenko 
 * Status: Proposed
-* Created: 06-Apr-2020
+* Created: 12-Apr-2020
 * License: CC0
 * Forking: hard-fork needed 
 
 ### Contents
 - [Background And Motivation](#background-and-motivation)
 - [Well-known Contract Format](#well-known-contract-format)
-- [Contracts Repositiory](#contracts-repositiory)
-- [Cost Estimation](#cost-Estimation) 
-- [Transaction Validation](#transaction-validation) 
-- [Extension by Soft-Forkability](#extension-by-soft-forkability) 
-- [Changes in The Reference Implementation](#changes-in-the-reference-implementation) 
+- [Well-known Contracts List](#well-known-contracts-list)
+- [Implementation of The Standard](#implementation-of-the-standard)
+  - [Changes in Serialization](#changes-in-serialization)
+  - [Changes in Costing](#changes-in-costing)
 
 ### Background And Motivation
 
@@ -59,46 +58,49 @@ added to the [list in the following section](#well-known-contracts-list).
 
 To specify a new well-known contract one needs:
 
-1) Obtain a the last registered well-known contract from [the list of well-known contracts](#well-known-contracts-list).
+1) Obtain a the last registered well-known contract from [the list of well-known
+contracts](#well-known-contracts-list).
 
-1) Obtain `contractId` and the current counter value `C` from the contract registration record.
+1) Obtain `lastContractId` and the current counter value `C` from the most recent contract
+registration record.
 
 1) Describe the contract template according to [EIP-0005](eip-0005.md) and obtain its
-serialized bytes `contractBytes`.
+serialized bytes `contractBytes`. We impose an additional requirement that the number of
+segregated constants of the contract template is equal to the number of parameters. This
+is important to allow the same template (with exactly the same bytes) to be reused across
+many different ErgoTree instances of well-known contracts.
 
-1) Put `Foundation 2-out-of-6 Signature` and creating the
-new WCB with the following parameters
-```
-{
-  value: MinErg, 
-  proposition: ${CounterContract},
-  R2: { WCBTokenId -> 1 },
-  R4: C + 1
-  R5: "boxId|contractBytes"
-}
-```
+1) Sign the "lastContractId|contractBytes" bytes with `Foundation Signature` (which can be
+a threshold `2-out-of-6` or similar signature) and obtain `signatureBytes`.
 
-1) Add new contract to the list of the next section using the following data
+1) Add a new contract registration data as a sub-section of the [next
+section](#well-known-contracts-list) using the data described in th
 
-Column           | Value            | Description
------------------|------------------|------------------
-`Code`           | C + 1            | New code of the  
-`Name`           | "feeProposition" | User readable name UTF-8 encoding
-`Code`           | 0x0001           | Contract Code unique in the [repository](#contracts-repository)
-`Template`       | Base16"36a58ed5" | Contract Template bytes with parameter placeholders
-`Parameters`     | delta: Int       | Typed template parameter, array of (name, Type) pairs
+1) Obtain a new `contractId` bytes by running `Blake2b256((C+1)|lastContractId|contractBytes|signatureBytes)`
+
+Column           | Value              | Description
+-----------------|--------------------|------------------
+`contractId`     | `contractId`       | The hash of the contract registration content 
+`contractCode`   | C + 1              | The next code of the contract
+`prevContractId` | `lastContractId`   | The hash of the previous registered contract 
+`contractBytes`  | `Base16` or `File` | Contract Template bytes according to [EIP-0005](eip-0005.md) 
+`contractSig`    | `Base16` or `File` | The `signatureBytes` as Base16
 
 ### Well-known Contracts List
 
 Each well-known contract must be added here in a sub-section and described according to
-the [well-known contract format](#well-known-contract-format)
+the [well-known contract format](#well-known-contract-format). Each contract refers to the
+previous contract using its id thus forming a chain of contract registrations. The
+consistency of the whole chain and signatures can be verified by the software implemening
+both [EIP-0005](eip-0005.md) and this standard.
 
-#### RewardOutputScript 
+#### RewardOutputScript contract
 
 ```json
 {
-  "parentHash": "",
+  "contractId": "2025692038620398",
   "contractCode": 1,
+  "prevContractId": "",
   "contractTemplate": {
     "name": "RewardOutputScript",
     "description": "holds mining rewards",
@@ -113,36 +115,49 @@ the [well-known contract format](#well-known-contract-format)
        }
     ]
   },
-  "pgpSignature": "" 
+  "contractSignature": "11010823470091823840001349712304860891123948601298723" 
 }
 ```
 
-### Well-known Counter Boxes
+### Implementation of The Standard
 
-Each well-known contract needs to obtain a sequence number, a simple and compact contract
-identifier. This counter can be obtained with the help of [Ergo Counter commands]() of
-ErgoTool. The Ergo counters are implemented using [Counter Contract]() template and can be
-used for various applications. We create a special counter to enumerate well-known
-contracts and store them on the Ergo blockchain.
+The extension is fully encapsulated (localized) in the implementation of ErgoTree and
+transparent to the rest of the protocol except cost estimation (see [sub-section
+below](#changes-in-costing)). The standard requires extending of the serialization format
+of ErgoTree.
 
-### Cost Estimation
+#### Changes in Serialization
 
-### Transaction Validation
+The `Bit 5` reserved in the `header` of ErgoTree (which is `0` by default, see
+[ErgoTree](https://ergoplatform.org/docs/ErgoTree.pdf) section _ErgoTree serialization_)
+can be set to `1` to indicate the contract is _well-known_. When the `Bit 5`
+(`WellKnownContractBit`) is set the `root` slot contains the `contractCode` of one of the
+well-known contracts registered in the list above
 
-Here we describe an extension to the existing Ergo protocol, which allows accelerated and more secure execution
-of well-known scripts. The extension doesn't require changes in the
-serialization format. Moreover, simple _transfer transactions_ are processed the same way so
-that 1) most existing applications (like exchanges) will not require any changes and 2)
-the new protocol doesn't incure additional overhead for simple transfer transactions.
+Slot           | Format      | #bytes   | Description
+---------------|-------------|----------|-----
+_header_       | VLQ(UInt)   | [1, *]   | The header with `Bit 5` set to 1
+...            |             |          | other slots of ErgoTree
+root           | VLQ(UInt)   | [1, *]   | `contractCode` of a registered well-known contract
 
-On a high level, the new protocol for transaction creation, signing and validation is
-described as a series of steps. 
+To deserialize the ErgoTree with `WellKnownContractBit == 1` every compliant protocol
+implementation should keep a mapping between contract codes and contract templates. When
+the `contractCode` is deserialized it can be used to lookup the contract template in the
+mapping. Thus obtained contract template is then used as the `root` expression tree of the
+ErgoTree instance. The `contractCode` value is also stored in the ErgoTree instance.
 
-1) 
+Note, that the same well-known contract template instance can be shared across all
+ErgoTree instances, since the parameters are all segregated. This not only completely
+avoids the deserialization of well-known templates, but also reduces memory footprint (and
+GC pressure) during massive transaction processing.
 
-2) 
- 
-3) 
+#### Changes in Costing
 
-### Changes In The Reference Implementation
+Cost estimation can be optimized for some of the well-known contracts by associating a
+fixed `cost` value with each contract. This association can be stored as `wellKnownCosts`
+data in the extensions section of each Block and updated by miners via voting.
+
+When an input is protected by a well-known contract, then `wellKnownCosts` table can be looked
+up to quickly obtain script verification cost. This cost can be accumulated to the total
+block cost.
 

--- a/eip-0006.md
+++ b/eip-0006.md
@@ -1,4 +1,4 @@
-# EIP-0006: Informal Multi-Stage Specification Format
+# EIP-0006: Informal Multi-Stage Protocol Specification Format
 
 * Author: Robert Kornacki
 * Status: Proposed
@@ -7,36 +7,68 @@
 * Forking: No fork needed 
 
 ### Contents
+- [Terminology](#Terminology)
 - [Background And Motivation](#background-and-motivation)
-- [How Informal Multi-Stage Contract Specs Are Written](#How-Informal-Multi-Stage-Contract-Specs-Are-Written)
+- [How Informal Multi-Stage Protocol Specs Are Written](#How-Informal-Multi-Stage-Protocol-Specs-Are-Written)
 - [Alternative Formatting](#Alternative-formatting)
-- [Example NFT Auction Contract](#example-nft-auction-contract)
+- [Example NFT Auction Protocol](#example-nft-auction-protocol)
 - [Conclusion](#Conclusion)
+
+### Terminology
+
+
+##### Script/Contract
+The code which locks a given box/UTXO.
+
+##### Multi-Stage Protocol
+An on-chain smart-contract based protocol which consists of two or more stages.
+
+##### Stage
+A state within a multi-stage protocol that is reachable by users. A stage (omitting bootstrap stages) is strictly defined by its:
+1. Contract
+2. Values that are to be held in the registers
+
+Within the contract of each stage the following are also defined:
+1. Hard-coded values relevant to the given stage
+2. Spending paths/path conditions
+
+##### Bootstrap Stage
+An initial state within a multi-stage protocol which allows a user to join. It is not defined by a box with a given contract and set of registers, as this is a state where the user is bootstrapping their way into the multi-stage protocol at a particular stage.
+
+##### Hard-coded Values
+Values relevant to the contract which are encoded directly within it, rather than in a register. An expiration block height or a user's address are common examples of hard-coded values which will not change as the multi-stage protocol runs.
+
+##### Spending Path
+A spending path is an action which a user is allowed to perform from a given stage in order to progress forward in the multi-stage protocol. A single stage may have one or more spending paths, each of which has a set of path conditions.
+
+##### Path Conditions
+Path conditions (aka spending conditions), are logical checks which are encoded within a contract which allow/disallow a user from using a given spending path.
+
 
 ### Background And Motivation
 
-[Multi-stage contracts](https://link.springer.com/chapter/10.1007/978-3-030-31500-9_16) are a fascinating tool for implementing complex protocols on a UTXO-based system. They allow for great expressiveness and are generally approachable due to the fact that different phases of a protocol are cleanly separated into their own sub-contracts.
+[Multi-stage protocols](https://link.springer.com/chapter/10.1007/978-3-030-31500-9_16) are a fascinating tool for implementing complex dApps on a UTXO-based system. They allow for great expressiveness and are generally approachable due to the fact that different phases of a protocol are cleanly separated into their own contracts.
 
-With that said, multi-stage contracts are extremely nascent as a model. This means that though they may be simpler when compared to alternatives, complexity is still going to be present when dealing with protocols that require numerous stages. Furthermore, we could benefit from conveying to others how a protocol is supposed to be implemented and/or work without writing a single line of code.
+With that said, they are extremely nascent as a model for designing smart contract protocols. This means that though they may be simpler when compared to alternatives, complexity is still going to be present when building protocols that require numerous stages. Furthermore, we could benefit from conveying to others how a given protocol is supposed to be implemented and/or work without writing a single line of code.
 
-As such it would be quite handy to have a format to informally define specifications for our multi-stage contracts that is understandable, easily traversable, and can be used as a guide for eventually writing both the on-chain and off-chain code.
+As such it would be quite handy to have a format to informally define specifications for our multi-stage smart contract protocols that is understandable, easily traversable, and can be used as a guide for eventually writing both the on-chain and off-chain code.
 
 
 
-### How Informal Multi-Stage Contract Specs Are Written
+### How Informal Multi-Stage Protocol Specs Are Written
 
 Let's look at the markdown-based schema in it's entirety and drill down how it works below.
 
 ```md
-# Contract Name
-Contract preamble
+# Multi-Stage Protocol Name
+Preamble
 
 ## ToC
 1. [Bootstrap Stage](<#Bootstrap-Stage>)
 2. [X Stage](<#X-Stage>)
 
 ## Bootstrap Stage
-Preamble of how the contract is bootstrapped. 
+Preamble of how the protocol is bootstrapped. 
 
 ### List Of Paths
 - [Y Path](<#Y-Path>)
@@ -72,6 +104,7 @@ Preamble
 - R5: ...
 
 
+
 ### List Of Paths
 - [Y Path](<#Y-Path>)
  
@@ -102,24 +135,24 @@ Preamble
 
 ```
 
-As you can see above, each contract is made out of a number of **stages**. Each stage is a specific state in which an actor may find themeslves in within the contract. Except for the boostrap stage, we define the hard-coded values and and the registers of the given stage.
+As you can see above, each multi-stage protocol is made out of a number of **stages**. Each stage (except for the bootstrap stage) is a state that is reachable by a user. A stage is comprised of a specific contract which locks up tokens and data together with a set of registers. 
 
-Furthermore, from each stage you have one or more **paths**. These are state transitions from the current stage to another (or to itself recursively). Each path specifies the required **inputs boxes**, **output boxes**, and **path conditions**. Path conditions are the logical checks which are encoded within the script which must be met in order to allow for a state transition to occur and thus for said path to be taken.
+From each stage you have one or more **paths**, which are state transitions from the current stage to another (or to itself recursively). Each path specifies the required **inputs boxes**, **output boxes**, and **path conditions**. Path conditions are the logical checks which are encoded within the contract which must be met in order to allow for a state transition to occur and thus for said path to be taken.
 
-Finally, each path also **leads to** somewhere else. In other words, the state transition must move the tokens and data held under the current stage to another. Thus we specify the next stage that a path leads to or `Exit`. Exit signifies that this is an **exit path** meaning that the multi-stage contract is finished executing. This means that the locked data/tokens can "exit" the contract and thus be spent into a box that is not locked under any of the scripts/stages of our contract.
+Finally, each path also **leads to** somewhere else. In other words, the state transition must move the tokens and data held under the current stage to another. Thus we specify the next stage that a path leads to or `Exit`. Exit signifies that this is an **exit path** meaning that the multi-stage protocol is finished executing and the locked data/tokens can be used/moved as the user wishes into a new box of their choosing.
 
-In the Bootstrap Stage(s) there are no hard-coded values, registers, or path conditions because the user is not using a box that is currently locked under an existing stage/script, but instead is creating such a box. Depending on the complexity of a protocol, it is possible for a multi-stage contract to have one or more bootstrap stages (bootstrapping different actors into different stages in the protocol).
+In the Bootstrap Stage there are no hard-coded values, registers, or path conditions because the user has no box(es) which are in any of the stages of the protocol. Depending on the complexity of a protocol, it is possible for a multi-stage protocol to have one or more bootstrap stages (bootstrapping different actors into different stages in the protocol).
 
-Clearly writing out the inputs + outputs as well as the path conditions may feel a little verbose, however this is on purpose. One only needs to focus on the required inputs + outputs when writing off-chain code for creating a transaction for a given path. On the flip side, when writing code which will live on-chain (the script), one only needs to pay attention to the path conditions of a given stage.
+Clearly writing out the inputs + outputs as well as the path conditions may feel a little verbose, however this is on purpose. One only needs to focus on the required inputs + outputs when writing off-chain code for creating a transaction for a given path. On the flip side, when writing code which will live on-chain (the contracts), one only needs to pay attention to the path conditions of a given stage.
 
-Every stage, path, and the multi-stage contract itself has room for a preamble/explanation of what is going on in the given section. This allows for the spec writer to add extra comments and/or make clarifications so that it is painfully clear how the contract is supposed to work when sharing with others.
+Every stage, path, and the protocol itself has room for a preamble/explanation of what is going on in the given section. This allows for the spec writer to add extra comments and/or make clarifications so that it is painfully clear how the multi-stage protocol is supposed to work when sharing with others.
 
 Using markdown we get the benefit of being able to hyperlink the stages in the ToC, the paths for each stage, and where each path leads to. This provides us with a reasonable interface for going through informal specifications and gaining an understanding of how the different stages are inter-linked. With both an eagle's eye view using the ToC as well as with a targeted/sequential view via following path hyperlinks, we have the ability to dig into how the parts and the whole of any given informal specification work.
 
 
 ### Alternative Formatting
 
-If the list format is too crowded for inputs/outputs/conditions, the following format is available as well for more complicated stages which have a lot of registers and/or tokens.
+If the list format is too crowded for inputs/outputs/conditions, the following format is available as well for more complicated protocols which have a lot of registers and/or tokens.
 
 ```md
 #### Inputs 
@@ -142,15 +175,15 @@ If the list format is too crowded for inputs/outputs/conditions, the following f
 
 ```
 
-This allows one to use lists within each given section, thereby allowing for much more room to go into detail about specifics. This can be useful for scripts which use several registers across several boxes in their path conditions for example.
+This allows one to use lists within each given section, thereby allowing for much more room to go into detail about specifics. This can be useful for contracts which use several registers across several boxes in their path conditions for example.
 
-With all of that said, let's now look at an example informal specification which uses the above scheme/format to define an NFT auction contract.
-
-
+With all of that said, let's now look at an example informal specification which uses the above scheme/format to define an NFT auction protocol.
 
 
-# Example NFT Auction Contract
-This contract allows a user to initiate an on-chain auction for a NFT/singleton token which accepts bids in Ergs. This informal specification is based off of the discussion/original design from [this Ergo Forum thread](https://www.ergoforum.org/t/auctions-on-ergo/122).
+
+
+# Example NFT Auction Protocol
+This protocol allows a user to initiate an on-chain auction for a NFT/singleton token which accepts bids in Ergs. This informal specification is based off of the discussion/original design from [this Ergo Forum thread](https://www.ergoforum.org/t/auctions-on-ergo/122).
 
 
 ## ToC
@@ -160,7 +193,7 @@ This contract allows a user to initiate an on-chain auction for a NFT/singleton 
 
 ## Bootstrap Stage
 
-This stage allows a user to initiate the auction. It requires that they provide their NFT and a box with Erg which represents the starting bid. There are no hard-coded values, registers, or path conditions because this is the bootstrap stage and thus there is no box locked under a stage/script yet.
+This stage allows a user to initiate the auction. It requires that they provide their NFT and a box with Ergs which represents the starting bid. There are no hard-coded values, registers, or path conditions because this is the bootstrap stage and thus there is no contract yet.
 
 ### List Of Paths
 - [Initiate Auction Path](<#Initiate-Auction-Path>)
@@ -174,7 +207,7 @@ This stage allows a user to initiate the auction. It requires that they provide 
 
 
 #### Outputs
-1. A box locked under the Auction stage/script that holds the NFT and Ergs from the inputs, which also stores the auction holder's public key in register R4.
+1. A box locked under the Auction contract/stage that holds the NFT and Ergs from the inputs, which also stores the auction holder's public key in register R4.
 
 
 #### Leads To
@@ -193,6 +226,7 @@ In this stage the NFT is held up for auction and anyone who has enough Ergs can 
 ### Registers
 - R4: The current highest bidder's public key
 
+
 ### List Of Paths
 - [Bid Path](<#Bid-Path>)
 - [Conclude Auction Path](<#Conclude-Auction-Path>)
@@ -207,13 +241,13 @@ This path recurses the box back into the Auction stage with the new Ergs held in
 
 
 #### Outputs
-1. A new box locked under the Auction stage again which has the new bidder's public key in R4, the NFT, and the Ergs for the bid.
+1. A new box locked under the Auction contract again which has the new bidder's public key in R4, the NFT, and the Ergs for the bid.
 2. A box owned by the previous bidder which gives them back the Ergs which they bid.
 
 
 #### Path Conditions
-1. The current block height must be less than the auction end block height hard-coded into the script.
-2. The first output box must be locked under the Auction script and holds the bidder's public key in R4, the NFT, and Ergs totalling at least 0.5 Erg more than the previous bid.
+1. The current block height must be less than the auction end block height hard-coded into the contract.
+2. The first output box must be locked under the Auction contract and holds the bidder's public key in R4, the NFT, and Ergs totalling at least 0.5 Erg more than the previous bid.
 3. The second output box is owned by the previous bidder and has a total number of Ergs equal to their bid.
 
 
@@ -235,7 +269,7 @@ This path allows for the NFT and the funds to be redeemed to the auction winner 
 
 
 #### Path Conditions
-1. The current block height must be grater than the auction end block height hard-coded into the script.
+1. The current block height must be grater than the auction end block height hard-coded into the contract.
 2. The first output box must hold the NFT and be owned by the pub key stored in R4.
 3. The second output box must hold all of the Ergs and be owned by the auction holder.
 
@@ -248,12 +282,12 @@ Exit
 
 ### Conclusion
 
-The markdown-based schema outlined in this document provides the writer the feeling of freedom via easily changing whatever they've written as if it were an essay rather than the clunky feeling of writing compiled code (or a formal spec). 
+The informal markdown-based schema outlined in this document provides the writer the feeling of freedom via easily changing whatever they've written as if it were an essay rather than the clunky feeling of writing compiled code (or a formal spec). 
 This flexibility is useful when figuring out how to implement a protocol which typically requires making edits often and moving fast as previous ideas become obsolete and/or are found to be broken.
 
 Once an informal specification has been finalized, it can be used as a clear guide for:
 1. Writing a formal specification.
-2. Implementing the scripts in ErgoScript.
+2. Implementing the contracts in ErgoScript.
 3. Designing the off-chain transaction logic.
 
 As such it is my contention that utilizing this informal specification format is important for the long-term success of contracts and dApps on the Ergo Platform.

--- a/eip-0006.md
+++ b/eip-0006.md
@@ -1,4 +1,4 @@
-# EIP-0005: Well-known Contracts 
+# EIP-0006: Well-known Contracts 
 
 * Author: aslesarenko 
 * Status: Proposed
@@ -8,7 +8,7 @@
 
 ### Contents
 - [Background And Motivation](#background-and-motivation)
-- [Contract Format](#contract-format)
+- [Well-known Contract Format](#well-known-contract-format)
 - [Contracts Repositiory](#contracts-repositiory)
 - [Cost Estimation](#cost-Estimation) 
 - [Transaction Validation](#transaction-validation) 
@@ -53,21 +53,77 @@ well-known contracts out of serializable boxes, transactions, blocks and finally
 blockchain storage. It also allows to reduce validation time of both new block candidates
 and broadcasted blocks.
 
-### Contract Format
-Each well-known contract should be added to the [repository](#contracts-repository) by
-providing serialized bytes with the content fields described in the following table.
+### Well-known Contract Format
+Each _well-known contract_ must be specified and registered as it is described in this section and then
+added to the [list in the following section](#well-known-contracts-list).
 
-Field          |  Format            | Example          | Description
----------------|--------------------|------------------|-----------
-`NameLength`     | `VLQ(UShort)`    | 14               | Length of `Name` bytes 
-`Name`           | `Bytes`          | "feeProposition" | User readable name UTF-8 encoding
-`Code`           | `UShort`         | 0x0001           | Contract Code unique in the [repository](#contracts-repository)
-`Template`       | `Bytes`          | Base16"36a58ed5" | Contract Template bytes with parameter placeholders
-`Parameters`     | `ParameterSpec+` | delta: Int       | Typed template parameter, array of (name, Type) pairs
+To specify a new well-known contract one needs:
 
-### Contracts Repository
+1) Obtain a the last registered well-known contract from [the list of well-known contracts](#well-known-contracts-list).
 
-Contract Name
+1) Obtain `contractId` and the current counter value `C` from the contract registration record.
+
+1) Describe the contract template according to [EIP-0005](eip-0005.md) and obtain its
+serialized bytes `contractBytes`.
+
+1) Put `Foundation 2-out-of-6 Signature` and creating the
+new WCB with the following parameters
+```
+{
+  value: MinErg, 
+  proposition: ${CounterContract},
+  R2: { WCBTokenId -> 1 },
+  R4: C + 1
+  R5: "boxId|contractBytes"
+}
+```
+
+1) Add new contract to the list of the next section using the following data
+
+Column           | Value            | Description
+-----------------|------------------|------------------
+`Code`           | C + 1            | New code of the  
+`Name`           | "feeProposition" | User readable name UTF-8 encoding
+`Code`           | 0x0001           | Contract Code unique in the [repository](#contracts-repository)
+`Template`       | Base16"36a58ed5" | Contract Template bytes with parameter placeholders
+`Parameters`     | delta: Int       | Typed template parameter, array of (name, Type) pairs
+
+### Well-known Contracts List
+
+Each well-known contract must be added here in a sub-section and described according to
+the [well-known contract format](#well-known-contract-format)
+
+#### RewardOutputScript 
+
+```json
+{
+  "parentHash": "",
+  "contractCode": 1,
+  "contractTemplate": {
+    "name": "RewardOutputScript",
+    "description": "holds mining rewards",
+    "constants": "0204a00b08cd0279be667ef9dcbbac55a06295ce870b07029bfcdb2dce28d959f2815b16f81798",
+    "template": "ea02d192a39a8cc7a70173007301",
+    "parameters": [
+       { 
+         "name": "delta",
+         "description": "spending delay",
+         "type": "04",
+         "placeholder": 0
+       }
+    ]
+  },
+  "pgpSignature": "" 
+}
+```
+
+### Well-known Counter Boxes
+
+Each well-known contract needs to obtain a sequence number, a simple and compact contract
+identifier. This counter can be obtained with the help of [Ergo Counter commands]() of
+ErgoTool. The Ergo counters are implemented using [Counter Contract]() template and can be
+used for various applications. We create a special counter to enumerate well-known
+contracts and store them on the Ergo blockchain.
 
 ### Cost Estimation
 

--- a/eip-0006.md
+++ b/eip-0006.md
@@ -1,4 +1,4 @@
-# EIP-0006: Informal Multi-Stage Contract Specification Format
+# EIP-0006: Informal Multi-Stage Specification Format
 
 * Author: Robert Kornacki
 * Status: Proposed
@@ -102,24 +102,24 @@ Preamble
 
 ```
 
-As you can see above, each contract is made out of a number of **stages**. Each stage (except for the bootstrap stage) is a specific contract that the locks up tokens and data. Every stage has the ability to specify values which are hard-coded within the contract, and/or values which are stored in the registers.
+As you can see above, each contract is made out of a number of **stages**. Each stage is a specific state in which an actor may find themeslves in within the contract. Except for the boostrap stage, we define the hard-coded values and and the registers of the given stage.
 
-From each stage you have one or more **paths**, which are state transitions from the current stage to another (or to itself recursively). Each path specifies the required **inputs boxes**, **output boxes**, and **path conditions**. Path conditions are the logical checks which are encoded within the contract which must be met in order to allow for a state transition to occur and thus for said path to be taken.
+Furthermore, from each stage you have one or more **paths**. These are state transitions from the current stage to another (or to itself recursively). Each path specifies the required **inputs boxes**, **output boxes**, and **path conditions**. Path conditions are the logical checks which are encoded within the script which must be met in order to allow for a state transition to occur and thus for said path to be taken.
 
-Finally, each path also **leads to** somewhere else. In other words, the state transition must move the tokens and data held under the current stage to another. Thus we specify the next stage that a path leads to or `Exit`. Exit signifies that this is an **exit path** meaning that the multi-stage contract is finished executing and the locked data/tokens can be arbitrarily spent (thus exit the multi-stage contract).
+Finally, each path also **leads to** somewhere else. In other words, the state transition must move the tokens and data held under the current stage to another. Thus we specify the next stage that a path leads to or `Exit`. Exit signifies that this is an **exit path** meaning that the multi-stage contract is finished executing. This means that the locked data/tokens can "exit" the contract and thus be spent into a box that is not locked under any of the scripts/stages of our contract.
 
-In the Bootstrap Stage there are no hard-coded values, registers, or path conditions because there is no contract yet at this point. Depending on the complexity of a protocol, it is possible for a multi-stage contract to have one or more bootstrap stages (bootstrapping different actors into different stages in the protocol).
+In the Bootstrap Stage(s) there are no hard-coded values, registers, or path conditions because the user is not using a box that is currently locked under an existing stage/script, but instead is creating such a box. Depending on the complexity of a protocol, it is possible for a multi-stage contract to have one or more bootstrap stages (bootstrapping different actors into different stages in the protocol).
 
-Clearly writing out the inputs + outputs as well as the path conditions may feel a little verbose, however this is on purpose. One only needs to focus on the required inputs + outputs when writing off-chain code for creating a transaction for a given path. On the flip side, when writing code which will live on-chain (the contracts), one only needs to pay attention to the path conditions of a given stage.
+Clearly writing out the inputs + outputs as well as the path conditions may feel a little verbose, however this is on purpose. One only needs to focus on the required inputs + outputs when writing off-chain code for creating a transaction for a given path. On the flip side, when writing code which will live on-chain (the script), one only needs to pay attention to the path conditions of a given stage.
 
-Every stage, path, and the contract itself has room for a preamble/explanation of what is going on in the given section. This allows for the spec writer to add extra comments and/or make clarifications so that it is painfully clear how the multi-stage contract is supposed to work when sharing with others.
+Every stage, path, and the multi-stage contract itself has room for a preamble/explanation of what is going on in the given section. This allows for the spec writer to add extra comments and/or make clarifications so that it is painfully clear how the contract is supposed to work when sharing with others.
 
 Using markdown we get the benefit of being able to hyperlink the stages in the ToC, the paths for each stage, and where each path leads to. This provides us with a reasonable interface for going through informal specifications and gaining an understanding of how the different stages are inter-linked. With both an eagle's eye view using the ToC as well as with a targeted/sequential view via following path hyperlinks, we have the ability to dig into how the parts and the whole of any given informal specification work.
 
 
 ### Alternative Formatting
 
-If the list format is too crowded for inputs/outputs/conditions, the following format is available as well for more complicated contracts which have a lot of registers and/or tokens.
+If the list format is too crowded for inputs/outputs/conditions, the following format is available as well for more complicated stages which have a lot of registers and/or tokens.
 
 ```md
 #### Inputs 
@@ -142,7 +142,7 @@ If the list format is too crowded for inputs/outputs/conditions, the following f
 
 ```
 
-This allows one to use lists within each given section, thereby allowing for much more room to go into detail about specifics. This can be useful for contracts which use several registers across several boxes in their path conditions for example.
+This allows one to use lists within each given section, thereby allowing for much more room to go into detail about specifics. This can be useful for scripts which use several registers across several boxes in their path conditions for example.
 
 With all of that said, let's now look at an example informal specification which uses the above scheme/format to define an NFT auction contract.
 
@@ -160,7 +160,7 @@ This contract allows a user to initiate an on-chain auction for a NFT/singleton 
 
 ## Bootstrap Stage
 
-This stage allows a user to initiate the auction. It requires that they provide their NFT and a box with Erg which represents the starting bid. There are no hard-coded values, registers, or path conditions because this is the bootstrap stage and thus there is no contract yet.
+This stage allows a user to initiate the auction. It requires that they provide their NFT and a box with Erg which represents the starting bid. There are no hard-coded values, registers, or path conditions because this is the bootstrap stage and thus there is no box locked under a stage/script yet.
 
 ### List Of Paths
 - [Initiate Auction Path](<#Initiate-Auction-Path>)
@@ -174,7 +174,7 @@ This stage allows a user to initiate the auction. It requires that they provide 
 
 
 #### Outputs
-1. A box locked under the Auction contract/stage that holds the NFT and Ergs from the inputs, which also stores the auction holder's public key in register R4.
+1. A box locked under the Auction stage/script that holds the NFT and Ergs from the inputs, which also stores the auction holder's public key in register R4.
 
 
 #### Leads To
@@ -207,13 +207,13 @@ This path recurses the box back into the Auction stage with the new Ergs held in
 
 
 #### Outputs
-1. A new box locked under the Auction contract again which has the new bidder's public key in R4, the NFT, and the Ergs for the bid.
+1. A new box locked under the Auction stage again which has the new bidder's public key in R4, the NFT, and the Ergs for the bid.
 2. A box owned by the previous bidder which gives them back the Ergs which they bid.
 
 
 #### Path Conditions
-1. The current block height must be less than the auction end block height hard-coded into the contract.
-2. The first output box must be locked under the Auction contract and holds the bidder's public key in R4, the NFT, and Ergs totalling at least 0.5 Erg more than the previous bid.
+1. The current block height must be less than the auction end block height hard-coded into the script.
+2. The first output box must be locked under the Auction script and holds the bidder's public key in R4, the NFT, and Ergs totalling at least 0.5 Erg more than the previous bid.
 3. The second output box is owned by the previous bidder and has a total number of Ergs equal to their bid.
 
 
@@ -235,7 +235,7 @@ This path allows for the NFT and the funds to be redeemed to the auction winner 
 
 
 #### Path Conditions
-1. The current block height must be grater than the auction end block height hard-coded into the contract.
+1. The current block height must be grater than the auction end block height hard-coded into the script.
 2. The first output box must hold the NFT and be owned by the pub key stored in R4.
 3. The second output box must hold all of the Ergs and be owned by the auction holder.
 
@@ -253,7 +253,7 @@ This flexibility is useful when figuring out how to implement a protocol which t
 
 Once an informal specification has been finalized, it can be used as a clear guide for:
 1. Writing a formal specification.
-2. Implementing the contracts in ErgoScript.
+2. Implementing the scripts in ErgoScript.
 3. Designing the off-chain transaction logic.
 
 As such it is my contention that utilizing this informal specification format is important for the long-term success of contracts and dApps on the Ergo Platform.

--- a/eip-0006.md
+++ b/eip-0006.md
@@ -134,6 +134,10 @@ Preamble
 ## Action: X
 Preamble
 
+### Data-Inputs
+1. ...
+2. ...
+
 ### Inputs
 1. A box in [Stage A](<#Stage-A>).
 2. A box with at least x Erg.
@@ -143,7 +147,6 @@ Preamble
 1. A box in [Stage B](<#Stage-B>).
 2. ...
 3. ...
-
 
 ### Action Conditions
 1. ...
@@ -155,9 +158,9 @@ Preamble
 
 As you can see above, each smart contract protocol is made out of a number of **stages**. Each stage is a state that is reachable by a user. A stage is defined by a specific contract, the values expected to be in it's registers, and the values expected to be provided by context extension (user input during tx creation). There are also hard-coded values which are encoded within the contract itself.
 
-From each stage you have one or more **actions**. These are state transitions from the current stage to another (or to itself recursively with a mutation in either the data or tokens held). Each action specifies the required **inputs boxes**, **output boxes**, and **action conditions**. Action conditions are the logical checks which are encoded within the contract which must be met in order to allow for a state transition to occur and thus for said action (or spending path) to be taken.
+From each stage you have one or more **actions**. These are state transitions from the current stage to another (or to itself recursively with a mutation in either the data or tokens held). Each action specifies the required **data-inputs**, **inputs boxes**, **output boxes**, and **action conditions**. Action conditions are the logical checks which are encoded within the contract which must be met in order to allow for a state transition to occur and thus for said action (or spending path) to be taken.
 
-Note, bootstrap actions have no **action conditions** because there is no smart contract to enforce them yet. Furthermore, it is possible for a multi-stage protocol to have one or more bootstrap actions which allow different actors to enter the protocol potentially at different stages.
+Note, bootstrap actions have no **action conditions** because there is no smart contract to enforce them yet and no **data-inputs** because during bootstrapping data can be arbitrarily added by the user (no need to reference existing boxes). Furthermore, it is possible for a multi-stage protocol to have one or more bootstrap actions which allow different actors to enter the protocol potentially at different stages.
 
 Every stage, action, and the protocol itself has room for a preamble/explanation of what is going on in the given section. This allows for the spec writer to add extra comments and/or make clarifications so that it is painfully clear how the protocol is supposed to work when sharing with others.
 
@@ -166,25 +169,31 @@ Using markdown we get the benefit of being able to hyperlink the stages in the T
 
 ### Alternative Formatting
 
-If the list format is too crowded for inputs/outputs/conditions, the following format is available as well for more complicated protocols which have a lot of registers and/or tokens with heavy logical checks.
+If the list format is too crowded for inputs/outputs/conditions, the following format is available as well for more complicated protocols.
 
 ```md
-#### Inputs 
-##### Input #1
+### Data-Inputs 
+#### Data-Input #1
 ...
-##### Input #2
-...
-
-#### Outputs
-##### Ouput #1
-...
-##### Ouput #2
+##### Data-Input #2
 ...
 
-#### Action Conditions
-##### Condition 1
+### Inputs 
+#### Input #1
 ...
-##### Condition 2
+#### Input #2
+...
+
+### Outputs
+#### Ouput #1
+...
+#### Ouput #2
+...
+
+### Action Conditions
+#### Condition 1
+...
+#### Condition 2
 ...
 
 ```
@@ -249,6 +258,9 @@ This action allows a user to initiate an auction. It requires that they provide 
 ## Action: Bid On Auction
 This action recurses the Auction box back into the same stage however now with the newly bidded Ergs held inside and the current winning bidder in R4 updated.
 
+### Data-Inputs
+None
+
 ### Inputs
 1. The [Auction Stage](<#Stage-Auction>) box.
 2. Box(es) owned by the bidder which has enough Ergs to total the previous bid + 0.5 Erg.
@@ -269,16 +281,19 @@ This action recurses the Auction box back into the same stage however now with t
 ## Action: Conclude Auction
 This action allows the NFT and the funds to be redeemed to the auction winner and holder respectively once the auction finish height has been reached. If no one bid on the auction then the auction holder still has their public key in register R4, and therefore can redeem both their NFT and their Ergs to themselves.
 
-#### Inputs
+### Data-Inputs
+None
+
+### Inputs
 1. The [Auction Stage](<#Stage-Auction>) box.
 
 
-#### Outputs
+### Outputs
 1. A box owned by the address stored in R4 which holds the NFT.
 2. A box owned by the auction holder which receives all of the Ergs bid.
 
 
-#### Action Conditions
+### Action Conditions
 1. The current block height must be grater than the auction end block height hard-coded into the [Auction Stage](<#Stage-Auction>) contract.
 2. The first output box must hold the NFT and be owned by the pub key stored in R4.
 3. The second output box must hold all of the Ergs and be owned by the auction holder.

--- a/eip-0006.md
+++ b/eip-0006.md
@@ -30,13 +30,17 @@ A state within a multi-stage protocol that is reachable by users. A stage (omitt
 
 Within the contract of each stage the following are also defined:
 1. Hard-coded values relevant to the given stage
-2. Spending paths/path conditions
+2. Context extension values
+3. Spending paths/path conditions
 
 ##### Bootstrap Stage
 An initial state within a multi-stage protocol which allows a user to join. It is not defined by a box with a given contract and set of registers, as this is a state where the user is bootstrapping their way into the multi-stage protocol at a particular stage.
 
 ##### Hard-coded Values
 Values relevant to the contract which are encoded directly within it, rather than in a register. An expiration block height or a user's address are common examples of hard-coded values which will not change as the multi-stage protocol runs.
+
+##### Context Extension Values
+Input values which are expected to be provided by the user when they are creating a transaction to go down a spending path. Within the contract itself the context extension values are used in order to perform checks and calculations which are encoded within the path conditions.
 
 ##### Spending Path
 A spending path is an action which a user is allowed to perform from a given stage in order to progress forward in the multi-stage protocol. A single stage may have one or more spending paths, each of which has a set of path conditions.
@@ -99,6 +103,9 @@ Preamble
 ### Hard-coded Values
 - ...
 
+### Context Extension Values
+1. ...
+
 ### Registers
 - R4: ...
 - R5: ...
@@ -135,13 +142,13 @@ Preamble
 
 ```
 
-As you can see above, each multi-stage protocol is made out of a number of **stages**. Each stage (except for the bootstrap stage) is a state that is reachable by a user. A stage is comprised of a specific contract which locks up tokens and data together with a set of registers. 
+As you can see above, each multi-stage protocol is made out of a number of **stages**. Each stage (except for the bootstrap stage) is a state that is reachable by a user. A stage is comprised of a specific contract which locks up tokens and data together with a set of registers. There are also hard-coded values and context extension values which are encoded within the contract itself which we specify to make it clear what is going on within the contract.
 
 From each stage you have one or more **paths**, which are state transitions from the current stage to another (or to itself recursively). Each path specifies the required **inputs boxes**, **output boxes**, and **path conditions**. Path conditions are the logical checks which are encoded within the contract which must be met in order to allow for a state transition to occur and thus for said path to be taken.
 
 Finally, each path also **leads to** somewhere else. In other words, the state transition must move the tokens and data held under the current stage to another. Thus we specify the next stage that a path leads to or `Exit`. Exit signifies that this is an **exit path** meaning that the multi-stage protocol is finished executing and the locked data/tokens can be used/moved as the user wishes into a new box of their choosing.
 
-In the Bootstrap Stage there are no hard-coded values, registers, or path conditions because the user has no box(es) which are in any of the stages of the protocol. Depending on the complexity of a protocol, it is possible for a multi-stage protocol to have one or more bootstrap stages (bootstrapping different actors into different stages in the protocol).
+In the Bootstrap Stage there are no hard-coded values, context extension values, registers, or path conditions because the user has no box(es) which are in any of the stages of the protocol. Depending on the complexity of a protocol, it is possible for a multi-stage protocol to have one or more bootstrap stages (bootstrapping different actors into different stages in the protocol).
 
 Clearly writing out the inputs + outputs as well as the path conditions may feel a little verbose, however this is on purpose. One only needs to focus on the required inputs + outputs when writing off-chain code for creating a transaction for a given path. On the flip side, when writing code which will live on-chain (the contracts), one only needs to pay attention to the path conditions of a given stage.
 
@@ -222,6 +229,9 @@ In this stage the NFT is held up for auction and anyone who has enough Ergs can 
 ### Hard-coded Values
 - Auction holder's public key
 - Auction end block height
+
+### Context Extension Values
+None
 
 ### Registers
 - R4: The current highest bidder's public key

--- a/eip-0006.md
+++ b/eip-0006.md
@@ -216,7 +216,15 @@ With all of that said, let's now look at an example informal specification which
 
 
 # Example NFT Auction Protocol
-This protocol allows a user to initiate an on-chain auction for a NFT/singleton token which accepts bids in Ergs. This informal specification is based off of the discussion/original design from [this Ergo Forum thread](https://www.ergoforum.org/t/auctions-on-ergo/122).
+Trustless auctions for NFT/singleton tokens (token of total amount equal to one) are a useful use case for Blockchains. These NFTs can represent physical goods in the real world, or have meaning in relation to other dApps on-chain.
+
+As such NFTs can often be quite valuable and therefore a protocol for running on-chain auctions to sell a given NFT is going to be an important part of the smart contract stack.
+
+The following implementation focuses strictly on an NFT, however the protocol can be trivially expanded to support auctions for any tokens (or even sets of tokens) which a seller wishes to find a buyer for.
+
+The auction is initiated by the auction holder via the [Bootstrap Auction](<#Action-Bootstrap-Auction>) action, which starts the auction off at a predefined starting bid price. From there anyone on the Ergo Blockchain has the ability to use the [Bid On Auction](<#Action-Bid-On-Auction>) action until the auction end block height.
+
+Once the auction concludes [Conclude Auction](<#Action-Conclude-Auction>) can be used which provides the auction holder the Ergs from the auction, while providing the auction winner the NFT.
 
 ## Stage ToC
 1. [Auction Stage](<#Stage-Auction>)
@@ -270,9 +278,6 @@ This action allows a user to initiate an auction. It requires that they provide 
 ## Action: Bid On Auction
 This action recurses the Auction box back into the same stage however now with the newly bidded Ergs held inside and the current winning bidder in R4 updated.
 
-### Data-Inputs
-None
-
 ### Inputs
 1. The [Auction Stage](<#Stage-Auction>) box.
 2. Box(es) owned by the bidder which has enough Ergs to total the previous bid + 0.5 Erg.
@@ -292,9 +297,6 @@ None
 
 ## Action: Conclude Auction
 This action allows the NFT and the funds to be redeemed to the auction winner and holder respectively once the auction finish height has been reached. If no one bid on the auction then the auction holder still has their public key in register R4, and therefore can redeem both their NFT and their Ergs to themselves.
-
-### Data-Inputs
-None
 
 ### Inputs
 1. The [Auction Stage](<#Stage-Auction>) box.

--- a/eip-0006.md
+++ b/eip-0006.md
@@ -1,0 +1,92 @@
+# EIP-0005: Well-known Contracts 
+
+* Author: aslesarenko 
+* Status: Proposed
+* Created: 06-Apr-2020
+* License: CC0
+* Forking: hard-fork needed 
+
+### Contents
+- [Background And Motivation](#background-and-motivation)
+- [Contract Format](#contract-format)
+- [Contracts Repositiory](#contracts-repositiory)
+- [Cost Estimation](#cost-Estimation) 
+- [Transaction Validation](#transaction-validation) 
+- [Extension by Soft-Forkability](#extension-by-soft-forkability) 
+- [Changes in The Reference Implementation](#changes-in-the-reference-implementation) 
+
+### Background And Motivation
+
+Ergo is a blockchain designed for long-term survivability, resilience to attacks and
+security. To facilitate these goals the following parameters of the network should be
+optimized:
+- Blockchain storage size on full nodes
+- Speed of Block Candidate assembly from pooled transactions
+- transaction validation speed (txs/sec) 
+- minimal network traffic required for a node to stay connected and keep the pace of the
+blockchain growth (obtaining new blocks, broadcasting new candidates)
+- Node memory footprint 
+
+One of the opportunities to improve the network is to exploit the _stable_ nature of many
+useful contract templates (Here _stability_ means the new versions of the contracts are
+not created very often, if created at all):
+1) Ergo uses many contracts as part of its core protocol like
+`feeProposition`, `rewardOutputScript`, `foundationScript` etc. The contracts are fixed
+and are not supposed to be changed. 
+2) Many contracts such as those used in ErgoMix, DEX, Crowd Funding, etc. may become
+widely reusable. Many applications may be created on top of them. Such contracts have a
+natural tendency to be stable to keep backward compatibility with applications that use
+them.
+3) Stability of contracts also plays well with security. Intuitively, it feels very
+unsafe to send coins to an unknown contract. On the other hand, it is generally safe to
+send coins to the _well-known_ contracts, which have well described properties,
+verified by community experts and signed by network developers (or Foundation board
+members).
+
+However, despite the actual stability of many contracts, in the Ergo Protocol v1 their
+copies have to be saved in thousands of transactions and UTXO boxes which they protect.
+This significantly increases the blockchain size and UTXO memory footprint. It also have
+significant computational overhead due to parsing and cost limit control.
+
+This Ergo Improvement Proposal standardizes the protocol extension to factor those
+well-known contracts out of serializable boxes, transactions, blocks and finally out of the
+blockchain storage. It also allows to reduce validation time of both new block candidates
+and broadcasted blocks.
+
+### Contract Format
+Each well-known contract should be added to the [repository](#contracts-repository) by
+providing serialized bytes with the content fields described in the following table.
+
+Field          |  Format            | Example          | Description
+---------------|--------------------|------------------|-----------
+`NameLength`     | `VLQ(UShort)`    | 14               | Length of `Name` bytes 
+`Name`           | `Bytes`          | "feeProposition" | User readable name UTF-8 encoding
+`Code`           | `UShort`         | 0x0001           | Contract Code unique in the [repository](#contracts-repository)
+`Template`       | `Bytes`          | Base16"36a58ed5" | Contract Template bytes with parameter placeholders
+`Parameters`     | `ParameterSpec+` | delta: Int       | Typed template parameter, array of (name, Type) pairs
+
+### Contracts Repository
+
+Contract Name
+
+### Cost Estimation
+
+### Transaction Validation
+
+Here we describe an extension to the existing Ergo protocol, which allows accelerated and more secure execution
+of well-known scripts. The extension doesn't require changes in the
+serialization format. Moreover, simple _transfer transactions_ are processed the same way so
+that 1) most existing applications (like exchanges) will not require any changes and 2)
+the new protocol doesn't incure additional overhead for simple transfer transactions.
+
+On a high level, the new protocol for transaction creation, signing and validation is
+described as a series of steps. 
+
+1) 
+
+2) 
+ 
+3) 
+
+### Changes In The Reference Implementation
+

--- a/eip-0006.md
+++ b/eip-0006.md
@@ -1,4 +1,4 @@
-# EIP-0006: Informal Multi-Stage Protocol Specification Format
+# EIP-0006: Informal Smart Contract Protocol Specification Format
 
 * Author: Robert Kornacki
 * Status: Proposed
@@ -9,7 +9,7 @@
 ### Contents
 - [Terminology](#Terminology)
 - [Background And Motivation](#background-and-motivation)
-- [How Informal Multi-Stage Protocol Specs Are Written](#How-Informal-Multi-Stage-Protocol-Specs-Are-Written)
+- [How Informal Smart Contract Protocol Specs Are Written](#How-Informal-Smart-Contract-Protocol-Specs-Are-Written)
 - [Alternative Formatting](#Alternative-formatting)
 - [Example NFT Auction Protocol](#example-nft-auction-protocol)
 - [Conclusion](#Conclusion)
@@ -20,85 +20,72 @@
 ##### Script/Contract
 The code which locks a given box/UTXO.
 
+##### Smart Contract Protocol
+An on-chain smart-contract based protocol which consists of one or more stages and two or more possible actions.
+
 ##### Multi-Stage Protocol
-An on-chain smart-contract based protocol which consists of two or more stages.
+A smart-contract protocol with at least two or more stages.
 
 ##### Stage
-A state within a multi-stage protocol that is reachable by users. A stage (omitting bootstrap stages) is strictly defined by its:
+A state within a smart contract protocol that is reachable by users. A stage is strictly defined by its:
 1. Contract
-2. Values that are to be held in the registers
+2. Values that are to be held in the registers of the box locked by said contract
+3. Data that is to be provided by the user via context extension values
 
 Within the contract of each stage the following are also defined:
 1. Hard-coded values relevant to the given stage
-2. Context extension values
-3. Spending paths/path conditions
-
-##### Bootstrap Stage
-An initial state within a multi-stage protocol which allows a user to join. It is not defined by a box with a given contract and set of registers, as this is a state where the user is bootstrapping their way into the multi-stage protocol at a particular stage.
+2. Actions (Spending Paths)
 
 ##### Hard-coded Values
 Values relevant to the contract which are encoded directly within it, rather than in a register. An expiration block height or a user's address are common examples of hard-coded values which will not change as the multi-stage protocol runs.
 
 ##### Context Extension Values
-Input values which are expected to be provided by the user when they are creating a transaction to go down a spending path. Within the contract itself the context extension values are used in order to perform checks and calculations which are encoded within the path conditions.
+Input values which are expected to be provided by the user when they are creating a transaction to go down a spending path. Within the contract itself the context extension values are used in order to perform checks and calculations which are encoded within the spending conditions.
 
-##### Spending Path
-A spending path is an action which a user is allowed to perform from a given stage in order to progress forward in the multi-stage protocol. A single stage may have one or more spending paths, each of which has a set of path conditions.
+##### Action
+An action which a user is allowed to perform from a given stage in order to progress forward in the multi-stage protocol into a new state/stage. A single stage may have one or more actions (alternatively known as spending paths), each of which has a set of conditions.
 
-##### Path Conditions
-Path conditions (aka spending conditions), are logical checks which are encoded within a contract which allow/disallow a user from using a given spending path.
+##### Action Conditions
+Action conditions (aka spending conditions), are logical checks which are encoded within a contract which allow/disallow a user from using a given spending path/action.
+
+##### Bootstrap Action
+An action which allows a user to bootstrap themselves into one of the stages of the multi-stage protocol.
 
 
 ### Background And Motivation
 
-[Multi-stage protocols](https://link.springer.com/chapter/10.1007/978-3-030-31500-9_16) are a fascinating tool for implementing complex dApps on a UTXO-based system. They allow for great expressiveness and are generally approachable due to the fact that different phases of a protocol are cleanly separated into their own contracts.
+[UTXO-based smart contracts](https://link.springer.com/chapter/10.1007/978-3-030-31500-9_16) are a fascinating new area beginning to be explored for implementing dApp protocols. The model allows for great expressiveness and approachability due to the fact that different stages of a complex protocol can be cleanly separated into their own contracts.
 
-With that said, they are extremely nascent as a model for designing smart contract protocols. This means that though they may be simpler when compared to alternatives, complexity is still going to be present when building protocols that require numerous stages. Furthermore, we could benefit from conveying to others how a given protocol is supposed to be implemented and/or work without writing a single line of code.
+With that said, this is an extremely nascent model for designing smart contract protocols. This means that though they may be simpler when compared to the current standard today, complexity is still going to be present when building protocols that require numerous actions or stages. Furthermore, we could benefit from conveying to others how a given protocol is supposed to be implemented and/or work without writing a single line of code.
 
-As such it would be quite handy to have a format to informally define specifications for our multi-stage smart contract protocols that is understandable, easily traversable, and can be used as a guide for eventually writing both the on-chain and off-chain code.
+As such it would be quite handy to have a format to informally define specifications for our utxo-based smart contract protocols which are understandable, easily traversable, and can be used as a guide for eventually writing both the on-chain and off-chain code.
 
 
 
-### How Informal Multi-Stage Protocol Specs Are Written
+### How Informal Smart Contract Protocol Specs Are Written
 
 Let's look at the markdown-based schema in it's entirety and drill down how it works below.
 
 ```md
-# Multi-Stage Protocol Name
+# Smart Contract Protocol Name
 Preamble
 
-## ToC
-1. [Bootstrap Stage](<#Bootstrap-Stage>)
-2. [X Stage](<#X-Stage>)
-
-## Bootstrap Stage
-Preamble of how the protocol is bootstrapped. 
-
-### List Of Paths
-- [Y Path](<#Y-Path>)
- 
-### Y Path
-Preamble
-
-#### Inputs
-1. ...
-2. ...
-3. ...
+## Stage ToC
+1. [Stage A](<#Stage:-A>)
+2. [Stage B](<#Stage:-B>)
 
 
-#### Outputs
-1. ...
-2. ...
-3. ...
-
-
-#### Leads To
-[X Stage](<#X-Stage>)
-
+## Action ToC
+1. [Bootstrap Action](<#Action:-Bootstrap>)
+2. [X Action](<#Action:-X>)
 ---
 
-## X Stage
+## Stage: A
 Preamble
+
+### Registers
+- R4: ...
+- R5: ...
 
 ### Hard-coded Values
 - ...
@@ -106,60 +93,80 @@ Preamble
 ### Context Extension Values
 1. ...
 
+
+### Actions/Spending Paths
+- [X Action](<#Action:-X>)
+
+--- 
+
+## Stage: B
+Preamble
+
 ### Registers
 - R4: ...
 - R5: ...
 
+### Hard-coded Values
+- ...
 
+### Context Extension Values
+1. ...
 
-### List Of Paths
-- [Y Path](<#Y-Path>)
- 
-### Y Path
+### Actions/Spending Paths
+- [X Action](<#X-Action>)
+
+--- 
+
+## Action: Bootstrap
 Preamble
 
-#### Inputs
-1. ...
+### Inputs
+1. A box with at least y Erg.
+3. ...
+
+### Outputs
+1. A box in [Stage A](<#Stage:-A>) with X in R4.
+2. ...
+3. ...
+
+---
+
+## Action: X
+Preamble
+
+### Inputs
+1. A box in [Stage A](<#Stage:-A>).
+2. A box with at least x Erg.
+3. ...
+
+### Outputs
+1. A box in [Stage B](<#Stage:-B>).
 2. ...
 3. ...
 
 
-#### Outputs
+### Action Conditions
 1. ...
 2. ...
-3. ...
-
-
-#### Path Conditions
-1. ...
-2. ...
-
-
-#### Leads To
-`Hyperlinked name of next stage` OR `Exit`
 
 ---
 
 ```
 
-As you can see above, each multi-stage protocol is made out of a number of **stages**. Each stage (except for the bootstrap stage) is a state that is reachable by a user. A stage is comprised of a specific contract which locks up tokens and data together with a set of registers. There are also hard-coded values and context extension values which are encoded within the contract itself which we specify to make it clear what is going on within the contract.
+As you can see above, each multi-stage protocol is made out of a number of **stages**. Each stage is a state that is reachable by a user. A stage is defined by a specific contract, the values expected to be in it's registers, and the values expected to be provided by context extension (user input during tx creation). There are also hard-coded values which are encoded within the contract itself.
 
-From each stage you have one or more **paths**, which are state transitions from the current stage to another (or to itself recursively). Each path specifies the required **inputs boxes**, **output boxes**, and **path conditions**. Path conditions are the logical checks which are encoded within the contract which must be met in order to allow for a state transition to occur and thus for said path to be taken.
+From each stage you have one or more **actions**. These are state transitions from the current stage to another (or to itself recursively with a mutation in either the data or tokens held). Each action specifies the required **inputs boxes**, **output boxes**, and **action conditions**. Action conditions are the logical checks which are encoded within the contract which must be met in order to allow for a state transition to occur and thus for said action (or spending path) to be taken.
 
-Finally, each path also **leads to** somewhere else. In other words, the state transition must move the tokens and data held under the current stage to another. Thus we specify the next stage that a path leads to or `Exit`. Exit signifies that this is an **exit path** meaning that the multi-stage protocol is finished executing and the locked data/tokens can be used/moved as the user wishes into a new box of their choosing.
+Note, bootstrap actions have no **action conditions** because there is no smart contract to enforce them yet. Furthermore, it is possible for a multi-stage protocol to have one or more bootstrap actions which allow different actors to enter the protocol potentially at different stages.
 
-In the Bootstrap Stage there are no hard-coded values, context extension values, registers, or path conditions because the user has no box(es) which are in any of the stages of the protocol. Depending on the complexity of a protocol, it is possible for a multi-stage protocol to have one or more bootstrap stages (bootstrapping different actors into different stages in the protocol).
+Every stage, action, and the protocol itself has room for a preamble/explanation of what is going on in the given section. This allows for the spec writer to add extra comments and/or make clarifications so that it is painfully clear how the multi-stage protocol is supposed to work when sharing with others.
 
-Clearly writing out the inputs + outputs as well as the path conditions may feel a little verbose, however this is on purpose. One only needs to focus on the required inputs + outputs when writing off-chain code for creating a transaction for a given path. On the flip side, when writing code which will live on-chain (the contracts), one only needs to pay attention to the path conditions of a given stage.
-
-Every stage, path, and the protocol itself has room for a preamble/explanation of what is going on in the given section. This allows for the spec writer to add extra comments and/or make clarifications so that it is painfully clear how the multi-stage protocol is supposed to work when sharing with others.
-
-Using markdown we get the benefit of being able to hyperlink the stages in the ToC, the paths for each stage, and where each path leads to. This provides us with a reasonable interface for going through informal specifications and gaining an understanding of how the different stages are inter-linked. With both an eagle's eye view using the ToC as well as with a targeted/sequential view via following path hyperlinks, we have the ability to dig into how the parts and the whole of any given informal specification work.
+Using markdown we get the benefit of being able to hyperlink the stages in the ToC, the actions for each stage, and where each one leads to. This provides us with a reasonable interface for going through informal specifications and gaining an understanding of how the different stages are inter-linked. With both an eagle's eye view using the ToC as well as with a targeted/sequential view via following path hyperlinks, we have the ability to dig into how the parts and the whole of any given informal specification work.
 
 
 ### Alternative Formatting
 
-If the list format is too crowded for inputs/outputs/conditions, the following format is available as well for more complicated protocols which have a lot of registers and/or tokens.
+If the list format is too crowded for inputs/outputs/conditions, the following format is available as well for more complicated protocols which have a lot of registers and/or tokens with heavy logical checks.
 
 ```md
 #### Inputs 
@@ -174,7 +181,7 @@ If the list format is too crowded for inputs/outputs/conditions, the following f
 ##### Ouput #2
 ...
 
-#### Path Conditions
+#### Action Conditions
 ##### Condition 1
 ...
 ##### Condition 2
@@ -182,49 +189,31 @@ If the list format is too crowded for inputs/outputs/conditions, the following f
 
 ```
 
-This allows one to use lists within each given section, thereby allowing for much more room to go into detail about specifics. This can be useful for contracts which use several registers across several boxes in their path conditions for example.
+This allows one to use lists within each given section, thereby allowing for much more room to go into detail about specifics. This can be useful for contracts which use several registers across several boxes in their spending conditions for example.
 
 With all of that said, let's now look at an example informal specification which uses the above scheme/format to define an NFT auction protocol.
-
-
 
 
 # Example NFT Auction Protocol
 This protocol allows a user to initiate an on-chain auction for a NFT/singleton token which accepts bids in Ergs. This informal specification is based off of the discussion/original design from [this Ergo Forum thread](https://www.ergoforum.org/t/auctions-on-ergo/122).
 
-
-## ToC
-1. [Bootstrap Stage](<#bootstrap-stage>)
-2. [Auction Stage](<#auction-stage>)
+## Stage ToC
+1. [Auction Stage](<#Stage:-Auction>)
 
 
-## Bootstrap Stage
-
-This stage allows a user to initiate the auction. It requires that they provide their NFT and a box with Ergs which represents the starting bid. There are no hard-coded values, registers, or path conditions because this is the bootstrap stage and thus there is no contract yet.
-
-### List Of Paths
-- [Initiate Auction Path](<#Initiate-Auction-Path>)
-
-
-### Initiate Auction Path
-
-#### Inputs
-1. Box which holds the NFT that is to be put up for auction.
-2. Box with Ergs equivalent to the starting bid price.
-
-
-#### Outputs
-1. A box locked under the Auction contract/stage that holds the NFT and Ergs from the inputs, which also stores the auction holder's public key in register R4.
-
-
-#### Leads To
-[Auction Stage](<#Auction-Stage>)
+## Action ToC
+1. [Bootstrap Auction](<#Action:-Bootstrap-Auction>)
+2. [Bid On Auction](<#Action:-Bid-On-Auction>)
+2. [Conclude Auction](<#Action:-Conclude-Auction>)
 
 ---
 
 
-## Auction Stage
+## Stage: Auction
 In this stage the NFT is held up for auction and anyone who has enough Ergs can place a bid before the auction ends. All new bids must increment by at least 0.5 Erg.
+
+### Registers
+- R4: The current highest bidder's public key
 
 ### Hard-coded Values
 - Auction holder's public key
@@ -233,44 +222,53 @@ In this stage the NFT is held up for auction and anyone who has enough Ergs can 
 ### Context Extension Values
 None
 
-### Registers
-- R4: The current highest bidder's public key
+
+### Actions/Spending Paths
+- [Bid On Auction](<#Action:-Bid-On-Auction>)
 
 
-### List Of Paths
-- [Bid Path](<#Bid-Path>)
-- [Conclude Auction Path](<#Conclude-Auction-Path>)
+--- 
 
 
-### Bid Path
-This path recurses the box back into the Auction stage with the new Ergs held inside and the current winning bidder in R4 updated.
+## Action: Bootstrap Auction
+This action allows a user to initiate an auction. It requires that they provide their NFT and a box with Ergs which represents the starting bid.
 
 #### Inputs
-1. The auction box.
-2. Box(es) owned by the bidder which has enough Ergs to total the previous bid + 0.5 Erg.
+1. Box which holds the NFT that is to be put up for auction.
+2. Box with Ergs equivalent to the starting bid price.
 
 
 #### Outputs
-1. A new box locked under the Auction contract again which has the new bidder's public key in R4, the NFT, and the Ergs for the bid.
+1. A box locked under the [Auction Stage](<#Stage:-Auction>) that holds the NFT and Ergs from the inputs, which also stores the auction holder's public key in register R4.
+
+---
+
+
+## Action: Bid On Auction
+This action recurses the Auction box back into the same stage however now with the newly bidded Ergs held inside and the current winning bidder in R4 updated.
+
+### Inputs
+1. The [Auction Stage](<#Stage:-Auction>) box.
+2. Box(es) owned by the bidder which has enough Ergs to total the previous bid + 0.5 Erg.
+
+
+### Outputs
+1. A new box in the [Auction Stage](<#Stage:-Auction>) once again which has the new bidder's public key in R4, the NFT, and the Ergs for the bid.
 2. A box owned by the previous bidder which gives them back the Ergs which they bid.
 
 
-#### Path Conditions
-1. The current block height must be less than the auction end block height hard-coded into the contract.
-2. The first output box must be locked under the Auction contract and holds the bidder's public key in R4, the NFT, and Ergs totalling at least 0.5 Erg more than the previous bid.
+### Action Conditions
+1. The current block height must be less than the auction end block height hard-coded in the [Auction Stage](<#Stage:-Auction>) contract.
+2. The first output box must be locked under the [Auction Stage](<#Stage:-Auction>) and holds the bidder's public key in R4, the NFT, and Ergs totalling at least 0.5 Erg more than the previous bid.
 3. The second output box is owned by the previous bidder and has a total number of Ergs equal to their bid.
+---
 
 
-#### Leads To
-[Auction Stage](<#Auction-Stage>)
-
-
-### Conclude Auction Path
-
-This path allows for the NFT and the funds to be redeemed to the auction winner and holder respectively once the auction finish height has been reached. If no one bid on the auction then the auction holder still has their public key in register R4, and therefore can redeem both their NFT and their Ergs to themselves.
+## Action: Conclude Auction
+This action allows the NFT and the funds to be redeemed to the auction winner and holder respectively once the auction finish height has been reached. If no one bid on the auction then the auction holder still has their public key in register R4, and therefore can redeem both their NFT and their Ergs to themselves.
 
 #### Inputs
-1. The auction box.
+1. The [Auction Stage](<#Stage:-Auction>) box.
 
 
 #### Outputs
@@ -278,16 +276,13 @@ This path allows for the NFT and the funds to be redeemed to the auction winner 
 2. A box owned by the auction holder which receives all of the Ergs bid.
 
 
-#### Path Conditions
-1. The current block height must be grater than the auction end block height hard-coded into the contract.
+#### Action Conditions
+1. The current block height must be grater than the auction end block height hard-coded into the [Auction Stage](<#Stage:-Auction>) contract.
 2. The first output box must hold the NFT and be owned by the pub key stored in R4.
 3. The second output box must hold all of the Ergs and be owned by the auction holder.
-
-
-#### Leads To
-Exit
-
 ---
+---
+
 
 
 ### Conclusion

--- a/eip-0006.md
+++ b/eip-0006.md
@@ -71,13 +71,13 @@ Let's look at the markdown-based schema in it's entirety and drill down how it w
 Preamble
 
 ## Stage ToC
-1. [Stage A](<#Stage:-A>)
-2. [Stage B](<#Stage:-B>)
+1. [Stage A](<#Stage-A>)
+2. [Stage B](<#Stage-B>)
 
 
 ## Action ToC
-1. [Bootstrap Action](<#Action:-Bootstrap>)
-2. [X Action](<#Action:-X>)
+1. [Bootstrap Action](<#Action-Bootstrap>)
+2. [X Action](<#Action-X>)
 ---
 
 ## Stage: A
@@ -95,7 +95,7 @@ Preamble
 
 
 ### Actions/Spending Paths
-- [X Action](<#Action:-X>)
+- [X Action](<#Action-X>)
 
 --- 
 
@@ -125,7 +125,7 @@ Preamble
 3. ...
 
 ### Outputs
-1. A box in [Stage A](<#Stage:-A>) with X in R4.
+1. A box in [Stage A](<#Stage-A>) with X in R4.
 2. ...
 3. ...
 
@@ -135,12 +135,12 @@ Preamble
 Preamble
 
 ### Inputs
-1. A box in [Stage A](<#Stage:-A>).
+1. A box in [Stage A](<#Stage-A>).
 2. A box with at least x Erg.
 3. ...
 
 ### Outputs
-1. A box in [Stage B](<#Stage:-B>).
+1. A box in [Stage B](<#Stage-B>).
 2. ...
 3. ...
 
@@ -202,9 +202,9 @@ This protocol allows a user to initiate an on-chain auction for a NFT/singleton 
 
 
 ## Action ToC
-1. [Bootstrap Auction](<#Action:-Bootstrap-Auction>)
-2. [Bid On Auction](<#Action:-Bid-On-Auction>)
-2. [Conclude Auction](<#Action:-Conclude-Auction>)
+1. [Bootstrap Auction](<#Action-Bootstrap-Auction>)
+2. [Bid On Auction](<#Action-Bid-On-Auction>)
+3. [Conclude Auction](<#Action-Conclude-Auction>)
 
 ---
 
@@ -224,7 +224,9 @@ None
 
 
 ### Actions/Spending Paths
-- [Bid On Auction](<#Action:-Bid-On-Auction>)
+- [Bid On Auction](<#Action-Bid-On-Auction>)
+- [Conclude Auction](<#Action-Conclude-Auction>)
+
 
 
 --- 
@@ -239,7 +241,7 @@ This action allows a user to initiate an auction. It requires that they provide 
 
 
 #### Outputs
-1. A box locked under the [Auction Stage](<#Stage:-Auction>) that holds the NFT and Ergs from the inputs, which also stores the auction holder's public key in register R4.
+1. A box locked under the [Auction Stage](<#Stage-Auction>) that holds the NFT and Ergs from the inputs, which also stores the auction holder's public key in register R4.
 
 ---
 
@@ -248,18 +250,18 @@ This action allows a user to initiate an auction. It requires that they provide 
 This action recurses the Auction box back into the same stage however now with the newly bidded Ergs held inside and the current winning bidder in R4 updated.
 
 ### Inputs
-1. The [Auction Stage](<#Stage:-Auction>) box.
+1. The [Auction Stage](<#Stage-Auction>) box.
 2. Box(es) owned by the bidder which has enough Ergs to total the previous bid + 0.5 Erg.
 
 
 ### Outputs
-1. A new box in the [Auction Stage](<#Stage:-Auction>) once again which has the new bidder's public key in R4, the NFT, and the Ergs for the bid.
+1. A new box in the [Auction Stage](<#Stage-Auction>) once again which has the new bidder's public key in R4, the NFT, and the Ergs for the bid.
 2. A box owned by the previous bidder which gives them back the Ergs which they bid.
 
 
 ### Action Conditions
-1. The current block height must be less than the auction end block height hard-coded in the [Auction Stage](<#Stage:-Auction>) contract.
-2. The first output box must be locked under the [Auction Stage](<#Stage:-Auction>) and holds the bidder's public key in R4, the NFT, and Ergs totalling at least 0.5 Erg more than the previous bid.
+1. The current block height must be less than the auction end block height hard-coded in the [Auction Stage](<#Stage-Auction>) contract.
+2. The first output box must be locked under the [Auction Stage](<#Stage-Auction>) and holds the bidder's public key in R4, the NFT, and Ergs totalling at least 0.5 Erg more than the previous bid.
 3. The second output box is owned by the previous bidder and has a total number of Ergs equal to their bid.
 ---
 
@@ -268,7 +270,7 @@ This action recurses the Auction box back into the same stage however now with t
 This action allows the NFT and the funds to be redeemed to the auction winner and holder respectively once the auction finish height has been reached. If no one bid on the auction then the auction holder still has their public key in register R4, and therefore can redeem both their NFT and their Ergs to themselves.
 
 #### Inputs
-1. The [Auction Stage](<#Stage:-Auction>) box.
+1. The [Auction Stage](<#Stage-Auction>) box.
 
 
 #### Outputs
@@ -277,7 +279,7 @@ This action allows the NFT and the funds to be redeemed to the auction winner an
 
 
 #### Action Conditions
-1. The current block height must be grater than the auction end block height hard-coded into the [Auction Stage](<#Stage:-Auction>) contract.
+1. The current block height must be grater than the auction end block height hard-coded into the [Auction Stage](<#Stage-Auction>) contract.
 2. The first output box must hold the NFT and be owned by the pub key stored in R4.
 3. The second output box must hold all of the Ergs and be owned by the auction holder.
 ---

--- a/eip-0006.md
+++ b/eip-0006.md
@@ -37,19 +37,19 @@ Within the contract of each stage the following are also defined:
 2. Actions (Spending Paths)
 
 ##### Hard-coded Values
-Values relevant to the contract which are encoded directly within it, rather than in a register. An expiration block height or a user's address are common examples of hard-coded values which will not change as the multi-stage protocol runs.
+Values relevant to the contract which are encoded directly within it, rather than in a register. An expiration block height or a user's address are common examples of hard-coded values which will not change as the protocol runs.
 
 ##### Context Extension Values
 Input values which are expected to be provided by the user when they are creating a transaction to go down a spending path. Within the contract itself the context extension values are used in order to perform checks and calculations which are encoded within the spending conditions.
 
 ##### Action
-An action which a user is allowed to perform from a given stage in order to progress forward in the multi-stage protocol into a new state/stage. A single stage may have one or more actions (alternatively known as spending paths), each of which has a set of conditions.
+An action which a user is allowed to perform from a given stage in order to progress forward in the protocol into a new state/stage. A single stage may have one or more actions (alternatively known as spending paths), each of which has a set of conditions.
 
 ##### Action Conditions
 Action conditions (aka spending conditions), are logical checks which are encoded within a contract which allow/disallow a user from using a given spending path/action.
 
 ##### Bootstrap Action
-An action which allows a user to bootstrap themselves into one of the stages of the multi-stage protocol.
+An action which allows a user to bootstrap themselves into one of the stages of the protocol.
 
 
 ### Background And Motivation
@@ -153,13 +153,13 @@ Preamble
 
 ```
 
-As you can see above, each multi-stage protocol is made out of a number of **stages**. Each stage is a state that is reachable by a user. A stage is defined by a specific contract, the values expected to be in it's registers, and the values expected to be provided by context extension (user input during tx creation). There are also hard-coded values which are encoded within the contract itself.
+As you can see above, each smart contract protocol is made out of a number of **stages**. Each stage is a state that is reachable by a user. A stage is defined by a specific contract, the values expected to be in it's registers, and the values expected to be provided by context extension (user input during tx creation). There are also hard-coded values which are encoded within the contract itself.
 
 From each stage you have one or more **actions**. These are state transitions from the current stage to another (or to itself recursively with a mutation in either the data or tokens held). Each action specifies the required **inputs boxes**, **output boxes**, and **action conditions**. Action conditions are the logical checks which are encoded within the contract which must be met in order to allow for a state transition to occur and thus for said action (or spending path) to be taken.
 
 Note, bootstrap actions have no **action conditions** because there is no smart contract to enforce them yet. Furthermore, it is possible for a multi-stage protocol to have one or more bootstrap actions which allow different actors to enter the protocol potentially at different stages.
 
-Every stage, action, and the protocol itself has room for a preamble/explanation of what is going on in the given section. This allows for the spec writer to add extra comments and/or make clarifications so that it is painfully clear how the multi-stage protocol is supposed to work when sharing with others.
+Every stage, action, and the protocol itself has room for a preamble/explanation of what is going on in the given section. This allows for the spec writer to add extra comments and/or make clarifications so that it is painfully clear how the protocol is supposed to work when sharing with others.
 
 Using markdown we get the benefit of being able to hyperlink the stages in the ToC, the actions for each stage, and where each one leads to. This provides us with a reasonable interface for going through informal specifications and gaining an understanding of how the different stages are inter-linked. With both an eagle's eye view using the ToC as well as with a targeted/sequential view via following path hyperlinks, we have the ability to dig into how the parts and the whole of any given informal specification work.
 

--- a/eip-0006.md
+++ b/eip-0006.md
@@ -198,7 +198,7 @@ With all of that said, let's now look at an example informal specification which
 This protocol allows a user to initiate an on-chain auction for a NFT/singleton token which accepts bids in Ergs. This informal specification is based off of the discussion/original design from [this Ergo Forum thread](https://www.ergoforum.org/t/auctions-on-ergo/122).
 
 ## Stage ToC
-1. [Auction Stage](<#Stage:-Auction>)
+1. [Auction Stage](<#Stage-Auction>)
 
 
 ## Action ToC

--- a/eip-0006.md
+++ b/eip-0006.md
@@ -4,7 +4,7 @@
 * Status: Proposed
 * Created: 21-Apr-2020
 * License: CC0
-* Forking: No fork needed 
+* Forking: No fork needed
 
 ### Contents
 - [Terminology](#Terminology)
@@ -25,6 +25,9 @@ An on-chain smart-contract based protocol which consists of one or more stages a
 
 ##### Multi-Stage Protocol
 A smart-contract protocol with at least two or more stages.
+
+##### NFT/Singleton Token
+An NFT or singleton token is a non-fungible token which is unique. In other words, it is a token that is created with a quantity of 1, and thus is the only token in existence with it's given token id.
 
 ##### Stage
 A state within a smart contract protocol that is reachable by users. A stage is strictly defined by its:
@@ -103,7 +106,7 @@ Preamble
 ### Actions/Spending Paths
 - [X Action](<#Action-X>)
 
---- 
+---
 
 ## Stage: B
 Preamble
@@ -124,7 +127,7 @@ Preamble
 ### Actions/Spending Paths
 - [X Action](<#X-Action>)
 
---- 
+---
 
 ## Action: Bootstrap
 Preamble
@@ -181,13 +184,13 @@ Using markdown we get the benefit of being able to hyperlink the stages in the T
 If the list format is too crowded for inputs/outputs/conditions, the following format is available as well for more complicated protocols.
 
 ```md
-### Data-Inputs 
+### Data-Inputs
 #### Data-Input #1
 ...
 ##### Data-Input #2
 ...
 
-### Inputs 
+### Inputs
 #### Input #1
 ...
 #### Input #2
@@ -247,7 +250,7 @@ None
 
 
 
---- 
+---
 
 
 ## Action: Bootstrap Auction
@@ -313,7 +316,7 @@ None
 
 ### Conclusion
 
-The informal markdown-based schema outlined in this document provides the writer the feeling of freedom via easily changing whatever they've written as if it were an essay rather than the clunky feeling of writing compiled code (or a formal spec). 
+The informal markdown-based schema outlined in this document provides the writer the feeling of freedom via easily changing whatever they've written as if it were an essay rather than the clunky feeling of writing compiled code (or a formal spec).
 This flexibility is useful when figuring out how to implement a protocol which typically requires making edits often and moving fast as previous ideas become obsolete and/or are found to be broken.
 
 Once an informal specification has been finalized, it can be used as a clear guide for:

--- a/eip-0006.md
+++ b/eip-0006.md
@@ -34,10 +34,14 @@ A state within a smart contract protocol that is reachable by users. A stage is 
 
 Within the contract of each stage the following are also defined:
 1. Hard-coded values relevant to the given stage
-2. Actions (Spending Paths)
+2. Mandatory stage spending conditions
+3. Actions (spending paths)
 
 ##### Hard-coded Values
 Values relevant to the contract which are encoded directly within it, rather than in a register. An expiration block height or a user's address are common examples of hard-coded values which will not change as the protocol runs.
+
+#### Mandatory Stage Spending Conditions
+Logical checks/conditions which are encoded within the contract that must be met no matter which action is taken from the given stage. This is useful for multi-stage protocols with numerous actions per stage which you need to put wide limits on (Ex. Only allowing actions to be taken from a stage after a certain block height)
 
 ##### Context Extension Values
 Input values which are expected to be provided by the user when they are creating a transaction to go down a spending path. Within the contract itself the context extension values are used in order to perform checks and calculations which are encoded within the spending conditions.
@@ -93,6 +97,8 @@ Preamble
 ### Context Extension Values
 1. ...
 
+### Mandatory Stage Spending Conditions
+- ...
 
 ### Actions/Spending Paths
 - [X Action](<#Action-X>)
@@ -111,6 +117,9 @@ Preamble
 
 ### Context Extension Values
 1. ...
+
+### Mandatory Stage Spending Conditions
+- ...
 
 ### Actions/Spending Paths
 - [X Action](<#X-Action>)
@@ -156,7 +165,7 @@ Preamble
 
 ```
 
-As you can see above, each smart contract protocol is made out of a number of **stages**. Each stage is a state that is reachable by a user. A stage is defined by a specific contract, the values expected to be in it's registers, and the values expected to be provided by context extension (user input during tx creation). There are also hard-coded values which are encoded within the contract itself.
+As you can see above, each smart contract protocol is made out of a number of **stages**. Each stage is a state that is reachable by a user. A stage is defined by a specific contract, the values expected to be in it's registers, and the values expected to be provided by context extension (user input during tx creation). There are also hard-coded values which are encoded within the contract itself, and mandatory stage spending conditions which are logical checks that must be met in order for *any* action to take place. (If a given stage does not use one of these (ex. hard-coded values), then they can be omitted in order to save space.)
 
 From each stage you have one or more **actions**. These are state transitions from the current stage to another (or to itself recursively with a mutation in either the data or tokens held). Each action specifies the required **data-inputs**, **inputs boxes**, **output boxes**, and **action conditions**. Action conditions are the logical checks which are encoded within the contract which must be met in order to allow for a state transition to occur and thus for said action (or spending path) to be taken.
 


### PR DESCRIPTION
EIP-0006, seemed to be rebased back onto eip5 by mistake (and missed noticing). Nonetheless, the format is being currently used for protocols and is mature enough imo to be merged into master.