### PR TITLE
EIP-0019: Cold Wallet

### DIFF
--- a/eip-0019.md
+++ b/eip-0019.md
@@ -182,7 +182,7 @@ ColdSigningRequest data format and Cold Wallet replies back with ColdSigningResp
 Json format, holding
 * reducedTx (mandatory): Base64-encoded `ReducedTransaction` as defined above
 * sender (optional): P2PK address sending the transaction, can be used by cold wallets to determine which secret to use for signing the transaction
-* inputs (optional): List of base64-encoded serialized input boxes, can be used by cold wallets to show the user which boxes are burnt
+* inputs (mandatory): List of base64-encoded serialized input boxes, can be used by cold wallets to show the user which boxes are burnt
 
 ### ColdSigningResponse:
 Json format, holding

--- a/eip-0019.md
+++ b/eip-0019.md
@@ -198,12 +198,11 @@ As QR codes are length-limited and it could be needed to transfer the data in ch
 Examples:
 The QR code for a complete ColdSigningRequest contains the following data:
 
-     {"reducedTx":"....","sender":"9...","inputs":["...."]}
      {"CSR":"{\"reducedTx\":\"....\",\"sender\":\"9...\",\"inputs\":[\"...\"]}"}
 
 The QR code for the first chunk of a ColdSigningResponse with 3 pages total looks like the following:
 
-     {"CSTX":"{\"signedTx\":\"...\",\"s","n":3,"p":1}
+     {"CSTX":"{\"signedTx\":\"... (actual data, no valid JSON on its own)","n":3,"p":1}
 
 
 In addition to using the above formats the following requirements are imposed on

--- a/eip-0019.md
+++ b/eip-0019.md
@@ -135,7 +135,7 @@ method.
 This is because those context data is not required to generate proof (aka signature)
 once ErgoTree is reduced to ReductionResult containing sigma proposition.
 
-Having the `ReducedTransaction` data structure the the full transaction signing
+Having the `ReducedTransaction` data structure the full transaction signing
 consists of three steps
 
 1) Create unsigned transaction and then reduce it in the current

--- a/eip-0019.md
+++ b/eip-0019.md
@@ -101,17 +101,20 @@ serialization format called `ReducedTransaction`.
 ReducedTransaction:
   - unsignedTx: UnsignedTransaction
   - reducedInputs: Seq[ReducedInputData]
+  - txCost: Int
 
 UnsignedTransaction:
   - inputs: Seq[UnsignedInput],
   - dataInputs: Seq[DataInput],
-  - outputCandidates: Seq[ReductionResult]
+  - outputCandidates: Seq[ErgoBoxCandidate]
 
 UnsignedInput:
   - boxId: BoxId
   - extension: ContextExtension
 ```
 
+ReducedInputData:
+  - reductionResult: ReductionResult 
 Thus, the `ReducedTransaction` instance contains unsigned transaction augmented with
 one `ReductionResult` for each `UnsignedInput`. 
 

--- a/eip-0019.md
+++ b/eip-0019.md
@@ -9,6 +9,11 @@
 ## Contents
 - [Description](#description)
 - [Background And Motivation](#background-and-motivation)
+- [Reference Implementation](#reference-implementation)
+  - [Implementation in Mobile Wallet](#implementation-in-mobile-wallet)
+  - [Implementation in dApp](#implementation-in-dapp)
+- [Benefits for dApps](#benefits-for-dapps)
+- [Benefits for Mobile Wallets](#benefits-for-mobile-wallets)
 
 ## Description 
 This EIP defines a standard for cross-platform interaction between an online dApp

--- a/eip-0019.md
+++ b/eip-0019.md
@@ -1,0 +1,160 @@
+# Ergo Pay: an interaction protocol between mobile wallet and dApp
+
+* Author: @aslesarenko, @MrStahlfelge
+* Status: Proposed
+* Created: 18-August-2021
+* License: CC0
+* Forking: not needed 
+
+## Contents
+- [Description](#description)
+- [Background And Motivation](#background-and-motivation)
+
+## Description 
+This EIP defines a standard for cross-platform interaction between an online dApp
+and a mobile wallet for creating, signing and sending Ergo transactions.
+
+## Background And Motivation
+
+Mobile wallets, (hereafter _MW_), (like [Ergo Andorid Wallet]()) typically
+support scanning QR codes of [Payment
+Request](https://explorer.ergoplatform.com/payment-request?address=9er9hxmVcL8S4bNypCyJHpPEEkAfEd9CLq5gNrHN6s2pYomp55N&amount=0&description=).
+After scanning a payment request the MW can build a new transaction
+and then sign it using a secret key stored locally on the device.
+
+However, this only can be done for _simple_ transactions like transferring ERGs
+and assets between Pay-To-Public-Key addresses or transactions which only spend
+boxes from P2PK addresses. The reason for this is simple. In Ergo's eUTXO model
+a box can be protected by an arbitrary complex contract (aka spending
+condition) and a spending transaction should satisfy that condition by adding
+required context variables, creating expected number of outputs with specific
+registers etc. and all this depends on the contract. There is no way for a
+mobile wallet application to know all the details of all the possible contracts.
+
+On the contrary, every Ergo dApp is usually built on top of specific contracts.
+Business logic of dApp includes spending of the boxes protected by
+those application-specific contracts.
+Thus any dApp is in full control of creating transactions and thus can spend its
+own contracts without problems if only it could sign those transactions, but it
+cannot because signing requires knowledge of private keys which are not stored
+on the dApp, but instead stored on the mobile wallet.
+
+Thus, interaction between a dApp and a mobile wallet is required such that:
+1) the dApp builds a transaction and make it available for the mobile wallet
+2) mobile wallet signs the transaction and submits it to the blockchain also
+returning txId to the dApp
+3) dApp monitors the transaction and upon confirmations proceed with its
+business logic.
+
+In this 3 step process the main question is: 
+"How the transaction built in dApp can be transferred to the mobile wallet
+application so that it can be signed there?".
+
+Luckily, the design of Ergo contracts allows for a simple and universal
+implementation with full separation of transaction building from transaction
+signing. See [Reference Implementation](#reference-implementation) for details.
+
+## Reference Implementation 
+
+The main idea is to introduce a new data structure and serialization format
+called `ReducedTransaction`.
+
+```
+ReducedTransaction:
+  - unsignedTx: UnsignedErgoLikeTransaction
+  - reducedInputs: Seq[ReducedInputData]
+```
+Thus defined `ReducedTransaction` contains unsigned transaction augmented with
+reduced input data for each `UnsignedInput`.
+
+```
+ReducedInputData:
+  - reductionResult: ReductionResult
+
+ReductionResult:
+  - value: SigmaBoolean
+  - cost: Long
+```
+
+With this new ReducedTransaction data structure the signing process can be split
+into two independent steps.
+
+First step is to build unsigned transaction and then reduce it in the current
+blockchain context, which has connection to one of the network nodes.
+
+```
+val reducedTx: ReducedTransaction = ergoClient.execute { ctx: BlockchainContext =>
+  val unsigned = createTransaction(ctx, from, to, amountToSend, assets)
+  val prover = ctx.newProverBuilder.build // prover without secrets
+  prover.reduce(unsigned, 0)
+}
+```
+Reduced transaction data structure can be serialized to bytes and then passed to
+the mobile wallet (see [Implementation in dApp](#implementation-in-dapp) section
+for details).
+```
+val reducedTxBytes = ReducedTransactionSerializer.toBytes(reducedTx)
+```
+
+Once received in mobile wallet the bytes of the reduced transaction can be
+deserialized back into ReducedTransaction object.
+A special `ColdErgoClient` instance can be created to perform signing
+operations. `ColdErgoClient` don't have connections to Ergo nodes and explorer,
+moreover for better security, cold client can forbig operations if any
+device connectivity is turned-on, such as WiFi, Bluetooth, NFC, Cellular etc.
+Note, using ColdErgoClient is not strictly required and ordinary client can be
+used instead, however ColdErgoClient allows this EIP to be used in an
+implementation of Cold mobile wallets.
+
+```
+val reducedTx = ReducedTransactionSerializer.fromBytes(reducedTxBytes)
+
+val coldClient = new ColdErgoClient(NetworkType.MAINNET)
+
+val signedTx = coldClient.execute { ctx: BlockchainContext =>
+  // create prover in the cold context using secrets stored on this device
+  val prover = BoxOperations.createProver(ctx,
+    new File("storage/E2.json").getPath, "abc")
+    .build
+
+  prover.signReduced(reducedTx, 0)
+}
+```
+It is important to note, that signatures for all inputs of a reduced transaction
+can be generated directly, without script evaluation (aka script reduction) and
+and thus, mobile wallet don't need to construct complex spending contexts.
+
+
+### Implementation in Mobile Wallet
+TODO
+
+### Implementation in dApp
+TODO
+
+## Benefits for dApps
+Ergo Pay provides a fast, easy, and secure way for users to buy goods and
+services in a dApp or on a website. When supported, Ergo Pay can substantially
+increase checkout conversion rates, user loyalty and purchase frequency, and
+reduced checkout time. 
+
+- dApp of website don’t need to handle user's secrets (mnemonic/private keys).
+Instead, once the user has signed the transaction to confirm purchase intent,
+your app or website receives a transaction id to monitor payment status on the
+blockchain.
+- dApp's users don't need to worry about security of their private keys as the
+mobile wallet guarantees they never leave the mobile device
+- adding Ergo Pay to product detail pages, the cart, checkout page, in payment
+settings, or anywhere else a user can choose a payment method or initiate a
+purchase.
+- The payment sheet can be presented immediately after the user taps the Ergo
+Pay button, without any interim screens or pop-ups except to prompt for
+necessary product details, such as size or quantity.
+- Ergo Pay supports all smart contracts and offers the flexibility to implement
+simple to complex dApps.
+
+## Benefits for Mobile Wallets
+
+Any mobile wallet team should consider supporting Ergo Pay in their wallet along
+with basic wallet features. Users can participate in Ergo dApps and mobile
+wallet team can receive service fees from those transactions. 
+

--- a/eip-0019.md
+++ b/eip-0019.md
@@ -1,6 +1,6 @@
-# Ergo Pay: an interaction protocol between mobile wallet and dApp
+# Cold Wallet: an interaction protocol between Hot and Cold mobile wallets
 
-* Author: @aslesarenko, @MrStahlfelge
+* Author: @MrStahlfelge,@aslesarenko
 * Status: Proposed
 * Created: 18-August-2021
 * License: CC0
@@ -9,157 +9,206 @@
 ## Contents
 - [Description](#description)
 - [Background And Motivation](#background-and-motivation)
-- [Reference Implementation](#reference-implementation)
-  - [Implementation in Mobile Wallet](#implementation-in-mobile-wallet)
-  - [Implementation in dApp](#implementation-in-dapp)
-- [Benefits for dApps](#benefits-for-dapps)
-- [Benefits for Mobile Wallets](#benefits-for-mobile-wallets)
+- [Cold Signing Problem](#cold-signing-problem)
+- [Simplified Signing using ReducedTransaction](#simplified-signing-using-reducedtransaction)
+- [Transaction Interchange](#transaction-interchange)
+- [Reference Implementation of Hot Wallet](#reference-implementation-of-hot-wallet)
+- [Reference Implementation of Cold Wallet](#reference-implementation-of-cold-wallet)
+- [Benefits](#benefits)
 
 ## Description 
-This EIP defines a standard for cross-platform interaction between an online dApp
-and a mobile wallet for creating, signing and sending Ergo transactions.
+This EIP defines a standard for cross-device interaction between "Hot"
+and "Cold" mobile wallets for signing Ergo transactions.
 
 ## Background And Motivation
 
-Mobile wallets, (hereafter _MW_), (like [Ergo Andorid Wallet]()) typically
-support scanning QR codes of [Payment
-Request](https://explorer.ergoplatform.com/payment-request?address=9er9hxmVcL8S4bNypCyJHpPEEkAfEd9CLq5gNrHN6s2pYomp55N&amount=0&description=).
-After scanning a payment request the MW can build a new transaction
-and then sign it using a secret key stored locally on the device.
+Mobile wallets, (hereafter _MW_), (like [Ergo Andorid
+Wallet](https://github.com/MrStahlfelge/ergo-wallet-android)) typically store
+private keys (aka mnemonics) on the device.
 
-However, this only can be done for _simple_ transactions like transferring ERGs
-and assets between Pay-To-Public-Key addresses or transactions which only spend
-boxes from P2PK addresses. The reason for this is simple. In Ergo's eUTXO model
-a box can be protected by an arbitrary complex contract (aka spending
-condition) and a spending transaction should satisfy that condition by adding
-required context variables, creating expected number of outputs with specific
-registers etc. and all this depends on the contract. There is no way for a
-mobile wallet application to know all the details of all the possible contracts.
+However, modern mobile OSes (Andorid, iOS) are 24/7 connected to the internet
+and often can be
+[hacked](https://latesthackingnews.com/2021/07/30/apple-patched-zero-day-bug-under-attack-for-mac-and-ios-devices/)
+and secrets [stolen](https://latesthackingnews.com/2021/07/06/numerous-trojanized-android-apps-caught-stealing-users-facebook-credentials/)
 
-On the contrary, every Ergo dApp is usually built on top of specific contracts.
-Business logic of dApp includes spending of the boxes protected by
-those application-specific contracts.
-Thus any dApp is in full control of creating transactions and thus can spend its
-own contracts without problems if only it could sign those transactions, but it
-cannot because signing requires knowledge of private keys which are not stored
-on the dApp, but instead stored on the mobile wallet.
+That is why specialized [hardware wallets](https://www.ledger.com/) are
+considered much more secure to store private keys.
 
-Thus, interaction between a dApp and a mobile wallet is required such that:
-1) the dApp builds a transaction and make it available for the mobile wallet
-2) mobile wallet signs the transaction and submits it to the blockchain also
-returning txId to the dApp
-3) dApp monitors the transaction and upon confirmations proceed with its
-business logic.
+Another option is to use "Cold" wallet - a mobile device which is not connected
+to the internet or better yet, the device, on which all connectivity is turned-off.
+The ideal candidate is any outdated (but still functioning) device with clean
+factory setup and only Cold Wallet application installed.
 
-In this 3 step process the main question is: 
-"How the transaction built in dApp can be transferred to the mobile wallet
-application so that it can be signed there?".
+Interaction with the Cold Wallet device can be done via QR codes:
+1) A user creates a transaction in the Hot Wallet application and then
+presses the "Sign With Cold Wallet" button
+2) The Hot Wallet application shows a QR code with serialized transaction
+bytes on the screen
+3) User scans the QR code using the Cold Wallet device, signs the
+transaction after which QR code of the signed transaction is displayed.
+4) Then user scans the QR code of the signed transaction and sends it to blockchain.
 
-Luckily, the design of Ergo contracts allows for a simple and universal
-implementation with full separation of transaction building from transaction
-signing. See [Reference Implementation](#reference-implementation) for details.
+The design of Ergo contracts allows for a simple and universal implementation
+which we describe in [Reference Implementation](#reference-implementation)
+section.
 
-## Reference Implementation 
+In the following sections we:
+ 1) describe the main problem we need to solve; 
+ 2) describe a solution;  
+ 3) specify a protocol with two roles: HotWallet and
+ColdWallet which must be implemented by complying Wallet applications and 
+ 4) describe a reference implementation of both Hot and Cold roles in [Ergo Wallet
+for Android](https://github.com/MrStahlfelge/ergo-wallet-android).
 
-The main idea is to introduce a new data structure and serialization format
-called `ReducedTransaction`.
+## Cold Signing Problem
+
+In the Ergo's eUTXO model a box can be protected by an arbitrary complex
+contract (aka spending condition) and the spending transaction should satisfy
+that condition by adding required context variables, creating expected number of
+outputs with specific registers etc. i.e. a special data structure called
+`Context`. The Context should be created for each input of the transaction
+and then passed to the Prover which will generate a signature for that input.
+See [general overview of signing and
+verification](https://github.com/ScorexFoundation/sigmastate-interpreter#sigma-language-background)
+process in Ergo for details.
+
+In general, the Context represents the current state of the blockchain and
+includes current header, previous 10 headers, current height etc. This data can
+be retrieved from blockchain nodes. This is possible on Hot Wallet device, but
+is not possible on Cold Wallet device (there is no network connection).
+
+At the same time the prover need to know both the Context data and the private
+keys, which are stored on the Cold Wallet device, and so the Prover must run on
+the Cold Wallet device.
+
+And finally, which is the problem, we cannot transfer unsigned transaction along
+with all the contexts for each input to the Cold Wallet via QR code. 
+
+QR codes have limit of 4K bytes on the maximum size of serialized data. Most of
+the transactions with required Contexts will exceed this limit.
+
+## Simplified Signing using ReducedTransaction
+
+To solve the problem of _cold signing_ we need a new data structure and
+serialization format called `ReducedTransaction`.
 
 ```
 ReducedTransaction:
-  - unsignedTx: UnsignedErgoLikeTransaction
+  - unsignedTx: UnsignedTransaction
   - reducedInputs: Seq[ReducedInputData]
+
+UnsignedTransaction:
+  - inputs: Seq[UnsignedInput],
+  - dataInputs: Seq[DataInput],
+  - outputCandidates: Seq[ReductionResult]
+
+UnsignedInput:
+  - boxId: BoxId
+  - extension: ContextExtension
 ```
-Thus defined `ReducedTransaction` contains unsigned transaction augmented with
-reduced input data for each `UnsignedInput`.
+
+Thus, the `ReducedTransaction` instance contains unsigned transaction augmented with
+one `ReductionResult` for each `UnsignedInput`. 
 
 ```
-ReducedInputData:
-  - reductionResult: ReductionResult
-
 ReductionResult:
   - value: SigmaBoolean
   - cost: Long
 ```
 
-With this new ReducedTransaction data structure the signing process can be split
-into two independent steps.
+Note that `UnsignedInput` object doesn't contain `ergoTree`, `additionalTokens`,
+`additionalRegisters` and other properties of
+[ErgoBox](https://github.com/ScorexFoundation/sigmastate-interpreter/blob/4533b6a7ae86ada20f3136c70a67a920ae7c43e1/sigmastate/src/main/scala/org/ergoplatform/ErgoBox.scala#L51)
+which are necessary to perform
+[ErgoTree](https://github.com/ScorexFoundation/sigmastate-interpreter/blob/1a1b003bc30e490d8b5af30e7670227e54e682c2/sigmastate/src/main/scala/sigmastate/Values.scala#L1014)
+reduction and which are part of the
+[Context](https://github.com/ScorexFoundation/sigmastate-interpreter/blob/e5127f6743db824f7280881cd5c4ecd336075e2f/sigmastate/src/main/scala/org/ergoplatform/ErgoLikeContext.scala#L51)
+data structure required by the
+[prove](https://github.com/ScorexFoundation/sigmastate-interpreter/blob/f24833d8d4572d77e4a93e5b69360335cb2d7dc1/sigmastate/src/main/scala/sigmastate/interpreter/ProverInterpreter.scala#L104)
+method.
 
-First step is to build unsigned transaction and then reduce it in the current
-blockchain context, which has connection to one of the network nodes.
+This is because those context data is not required to generate proof (aka signature)
+once ErgoTree is reduced to ReductionResult containing sigma proposition.
+
+Having the `ReducedTransaction` data structure the the full transaction signing
+consists of three steps
+
+1) Create unsigned transaction and then reduce it in the current
+blockchain context, which has connection to one of the network nodes. This step
+is performed on Hot Wallet and produces ReducedTransaction without requiring
+secret keys.
 
 ```
-val reducedTx: ReducedTransaction = ergoClient.execute { ctx: BlockchainContext =>
-  val unsigned = createTransaction(ctx, from, to, amountToSend, assets)
-  val prover = ctx.newProverBuilder.build // prover without secrets
-  prover.reduce(unsigned, 0)
-}
-```
-Reduced transaction data structure can be serialized to bytes and then passed to
-the mobile wallet (see [Implementation in dApp](#implementation-in-dapp) section
-for details).
-```
-val reducedTxBytes = ReducedTransactionSerializer.toBytes(reducedTx)
+val ctx: BlockchainContext = ...
+val unsignedIx = createTransaction(ctx, from, to, amountToSend, assets)
+val prover = ctx.newProverBuilder.build // prover without secrets
+val reducedTx: ReducedTransaction = prover.reduce(unsigned, 0)
 ```
 
-Once received in mobile wallet the bytes of the reduced transaction can be
-deserialized back into ReducedTransaction object.
+2) Serialize ReducedTransaction data structure to bytes and then pass it to
+the Cold Wallet via QR code.
+
+3) Once scanned in the Cold Wallet, the ReducedTransaction object can be
+deserialized back from bytes and then signed using prover configured with local
+secrets.
+
+```
+val reducedTx = ReducedTransactionSerializer.fromBytes(reducedTxBytes)
+val ctx: ColdBlockchainContext = ...
+// create prover in the cold context using secrets stored on this device
+val prover = ctx.newProverBuilder.withSecretStorage("storage.json").build
+val signedTx = prover.signReduced(reducedTx)
+```
+
+It is important to note, that signatures for all inputs of the ReducedTransaction
+can be generated directly, without script evaluation (aka script reduction) and
+and thus, Cold Wallet don't need complex spending contexts.
+
+## Transaction Interchange
+
+For better security and usability additional data can be transfered between Hot
+and Cold wallets via QR codes. Hot Wallet passes data to the Cold Wallet using
+ColdSigningRequest data format and Cold Wallet replies back with ColdSigningResponse.
+
+```
+ColdSigningRequest:
+ - messageType: Byte = 1
+ - transaction: ReducedTransaction
+ - description: String
+
+ColdSigningResponse:
+ - messageType: Byte = 2
+ - transaction: SignedTransaction
+```
+
+In addition to using the above formats the following requirements are imposed on
+Hot Wallet and Cold Wallets:
+
+1) There should be a way for a given unsigend transaction on the HotWallet to
+show QR code of ColdSigningRequest on the screen, and then scan the QR code of
+the corresponding ColdSigningResponse.
+
+2) There should be a way on ColdWallet to scan QR code of ColdSigningRequest,
+show transaction details on the screen and allow user to either sign or reject.
+If signed, the QR code of ColdSigningResponse should be shown.
+
+## Reference Implementation of Hot Wallet 
+TODO
+
+## Reference Implementation of Cold Wallet
+TODO
+
 A special `ColdErgoClient` instance can be created to perform signing
 operations. `ColdErgoClient` don't have connections to Ergo nodes and explorer,
 moreover for better security, cold client can forbig operations if any
 device connectivity is turned-on, such as WiFi, Bluetooth, NFC, Cellular etc.
 Note, using ColdErgoClient is not strictly required and ordinary client can be
-used instead, however ColdErgoClient allows this EIP to be used in an
-implementation of Cold mobile wallets.
+used instead, however ColdErgoClient allows this EIP to be easily supported in an
+implementation of Cold Wallet application based on Appkit.
 
-```
-val reducedTx = ReducedTransactionSerializer.fromBytes(reducedTxBytes)
+## Benefits
 
-val coldClient = new ColdErgoClient(NetworkType.MAINNET)
-
-val signedTx = coldClient.execute { ctx: BlockchainContext =>
-  // create prover in the cold context using secrets stored on this device
-  val prover = BoxOperations.createProver(ctx,
-    new File("storage/E2.json").getPath, "abc")
-    .build
-
-  prover.signReduced(reducedTx, 0)
-}
-```
-It is important to note, that signatures for all inputs of a reduced transaction
-can be generated directly, without script evaluation (aka script reduction) and
-and thus, mobile wallet don't need to construct complex spending contexts.
-
-
-### Implementation in Mobile Wallet
-TODO
-
-### Implementation in dApp
-TODO
-
-## Benefits for dApps
-Ergo Pay provides a fast, easy, and secure way for users to buy goods and
-services in a dApp or on a website. When supported, Ergo Pay can substantially
-increase checkout conversion rates, user loyalty and purchase frequency, and
-reduced checkout time. 
-
-- dApp of website don’t need to handle user's secrets (mnemonic/private keys).
-Instead, once the user has signed the transaction to confirm purchase intent,
-your app or website receives a transaction id to monitor payment status on the
-blockchain.
-- dApp's users don't need to worry about security of their private keys as the
-mobile wallet guarantees they never leave the mobile device
-- adding Ergo Pay to product detail pages, the cart, checkout page, in payment
-settings, or anywhere else a user can choose a payment method or initiate a
-purchase.
-- The payment sheet can be presented immediately after the user taps the Ergo
-Pay button, without any interim screens or pop-ups except to prompt for
-necessary product details, such as size or quantity.
-- Ergo Pay supports all smart contracts and offers the flexibility to implement
-simple to complex dApps.
-
-## Benefits for Mobile Wallets
-
-Any mobile wallet team should consider supporting Ergo Pay in their wallet along
-with basic wallet features. Users can participate in Ergo dApps and mobile
-wallet team can receive service fees from those transactions. 
+Any mobile wallet can become compatible with this EIP by implementing HotWallet
+role in addition to basic wallet features. 
+Any Hot wallet implementation can interact with any Cold wallet implementation.
 

--- a/eip-0019.md
+++ b/eip-0019.md
@@ -189,21 +189,21 @@ Json format, holding
 * signedTx (mandatory): Base64-encoded `SignedTransaction`
 
 ### Interchange format
-As QR codes are length-limited and it could be needed to transfer the data in chunks, it is needed to wrap the actual data sent by a small layer containing information about number of chunk pages and page index of a chunk. This is done by adding a prefix to the data defined above:
+As QR codes are length-limited and it could be needed to transfer the data in chunks, it is needed to wrap the actual data sent by a small layer containing information about number of chunk pages and page index of a chunk. This is done by wrapping it in another JSON container with three properties:
 
-* Constant CSR for ColdSigningRequest or CSTX for ColdSigningResponse
-* (if pages num > 1) const / and 1-based page index of current chunk
-* (if pages num > 1) const / and pages num
-* const -
+* The actual chunk data, named CSR for ColdSigningRequest or CSTX for ColdSigningResponse
+* property "p", 1-based page index of current chunk (optional if there is only one page)
+* property "n", number of pages (optional if there is only one page)
 
 Examples:
 The QR code for a complete ColdSigningRequest contains the following data:
 
-     CSR-{"reducedTx":"....","sender":"9...","inputs":["...."]}
+     {"reducedTx":"....","sender":"9...","inputs":["...."]}
+     {"CSR":"{\"reducedTx\":\"....\",\"sender\":\"9...\",\"inputs\":[\"...\"]}"}
 
 The QR code for the first chunk of a ColdSigningResponse with 3 pages total looks like the following:
 
-     CSTX/1/3-{"signedTx":"..."}
+     {"CSTX":"{\"signedTx\":\"...\",\"s","n":3,"p":1}
 
 
 In addition to using the above formats the following requirements are imposed on

--- a/eip-0019.md
+++ b/eip-0019.md
@@ -175,16 +175,33 @@ For better security and usability additional data can be transfered between Hot
 and Cold wallets via QR codes. Hot Wallet passes data to the Cold Wallet using
 ColdSigningRequest data format and Cold Wallet replies back with ColdSigningResponse.
 
-```
-ColdSigningRequest:
- - messageType: Byte = 1
- - transaction: ReducedTransaction
- - description: String
+### ColdSigningRequest
+Json format, holding
+* reducedTx (mandatory): Base64-encoded `ReducedTransaction` as defined above
+* sender (optional): P2PK address sending the transaction, can be used by cold wallets to determine which secret to use for signing the transaction
+* inputs (optional): List of base64-encoded serialized input boxes, can be used by cold wallets to show the user which boxes are burnt
 
-ColdSigningResponse:
- - messageType: Byte = 2
- - transaction: SignedTransaction
-```
+### ColdSigningResponse:
+Json format, holding
+* signedTx (mandatory): Base64-encoded `SignedTransaction`
+
+### Interchange format
+As QR codes are length-limited and it could be needed to transfer the data in chunks, it is needed to wrap the actual data sent by a small layer containing information about number of chunk pages and page index of a chunk. This is done by adding a prefix to the data defined above:
+
+* Constant CSR for ColdSigningRequest or CSTX for ColdSigningResponse
+* (if pages num > 1) const / and 1-based page index of current chunk
+* (if pages num > 1) const / and pages num
+* const -
+
+Examples:
+The QR code for a complete ColdSigningRequest contains the following data:
+
+     CSR-{"reducedTx":"....","sender":"9...","inputs":["...."]}
+
+The QR code for the first chunk of a ColdSigningResponse with 3 pages total looks like the following:
+
+     CSTX/1/3-{"signedTx":"..."}
+
 
 In addition to using the above formats the following requirements are imposed on
 Hot Wallet and Cold Wallets:
@@ -198,10 +215,10 @@ show transaction details on the screen and allow user to either sign or reject.
 If signed, the QR code of ColdSigningResponse should be shown.
 
 ## Reference Implementation of Hot Wallet 
-TODO
+* https://github.com/ergoplatform/ergo-wallet-android
 
 ## Reference Implementation of Cold Wallet
-TODO
+* https://github.com/ergoplatform/ergo-wallet-android
 
 A special `ColdErgoClient` instance can be created to perform signing
 operations. `ColdErgoClient` don't have connections to Ergo nodes and explorer,

--- a/eip-0019.md
+++ b/eip-0019.md
@@ -17,31 +17,36 @@
 - [Benefits](#benefits)
 
 ## Description 
-This EIP defines a standard for cross-device interaction between "Hot"
-and "Cold" mobile wallets for signing Ergo transactions.
+This EIP defines a standard for cross-device interaction between "Hot" (online)
+and "Cold" (offline) wallets for signing Ergo transactions.
 
 ## Background And Motivation
 
-Mobile wallets, (hereafter _MW_), (like [Ergo Andorid
+Mobile wallets (like [Ergo Android
 Wallet](https://github.com/MrStahlfelge/ergo-wallet-android)) typically store
 private keys (aka mnemonics) on the device.
 
-However, modern mobile OSes (Andorid, iOS) are 24/7 connected to the internet
-and often can be
+However, modern mobile OSes (Android, iOS) as well as desktop PCs are always connected to the internet
+and can be
 [hacked](https://latesthackingnews.com/2021/07/30/apple-patched-zero-day-bug-under-attack-for-mac-and-ios-devices/)
-and secrets [stolen](https://latesthackingnews.com/2021/07/06/numerous-trojanized-android-apps-caught-stealing-users-facebook-credentials/)
+and secrets [stolen](https://latesthackingnews.com/2021/07/06/numerous-trojanized-android-apps-caught-stealing-users-facebook-credentials/).
+Screenreading and keystroke logging are system-independant ways to steal user data.
 
 That is why specialized [hardware wallets](https://www.ledger.com/) are
 considered much more secure to store private keys.
 
-Another option is to use "Cold" wallet - a mobile device which is not connected
-to the internet or better yet, the device, on which all connectivity is turned-off.
-The ideal candidate is any outdated (but still functioning) device with clean
-factory setup and only Cold Wallet application installed.
+Another option for more security is to use "Cold" wallet - a device which is not connected
+to the internet or better, with all connectivity turned-off and internet access blocked.
+Candidates could be outdated (but still functioning) mobile devices with clean
+factory setup or a Raspberry Pi with a fresh Raspbian setup and only Cold Wallet application installed.
+As long as the device never connects to the internet, it is guaranteed that no secrets left the device.
 
-Interaction with the Cold Wallet device can be done via QR codes:
+Interaction with the Cold Wallet device can be done via QR codes (in case of mobile devices)
+or by transferring files (in case of Raspberry Pi). For simplicity, only QR code is mentioned in the 
+following text. This does not mean any restriction of the transportation method.
+
 1) A user creates a transaction in the Hot Wallet application and then
-presses the "Sign With Cold Wallet" button
+presses a "Sign With Cold Wallet" button
 2) The Hot Wallet application shows a QR code with serialized transaction
 bytes on the screen
 3) User scans the QR code using the Cold Wallet device, signs the
@@ -184,7 +189,7 @@ ColdSigningResponse:
 In addition to using the above formats the following requirements are imposed on
 Hot Wallet and Cold Wallets:
 
-1) There should be a way for a given unsigend transaction on the HotWallet to
+1) There should be a way for a given unsigned transaction on the HotWallet to
 show QR code of ColdSigningRequest on the screen, and then scan the QR code of
 the corresponding ColdSigningResponse.
 
@@ -208,7 +213,9 @@ implementation of Cold Wallet application based on Appkit.
 
 ## Benefits
 
-Any mobile wallet can become compatible with this EIP by implementing HotWallet
+Any wallet can become compatible with this EIP by implementing HotWallet
 role in addition to basic wallet features. 
 Any Hot wallet implementation can interact with any Cold wallet implementation.
+Users have an alternative to specialized hardware wallets and can gain more security 
+for their funds stored on the Ergo Blockchain.
 


### PR DESCRIPTION
This standard, when supported by mobile wallets, can be used to create transactions in the Hot wallet (connected to network), pass them via QR codes to Cold Wallet (disconnected from network) for signing and then receiving the signed transaction back.
Benefits:
- Hot Wallet don't need private keys
- Cold Wallet don't need network connections and don't need to implement script reduction (only signature implementation is required)
