### PR TITLE
EIP-0022 md file for oracle pool 2.0

### DIFF
--- a/eip-0022.md
+++ b/eip-0022.md
@@ -1,0 +1,247 @@
+# Oracle Pool v2.0 [WIP]
+
+Below is a summary of the main new features in v2.0 and how it differs from v1.0
+
+1. Single pool address (only one type of box). This version of the pool will have only one address, the *pool address*. 
+2. Data-point boxes will be considered as inputs rather than data-inputs. These inputs will be spent, and a copy of the box with the reward will be created.
+3. Reward in tokens not Ergs. The posting reward will be in the form of tokens, which can be redeemed separately. 
+4. Reward accumulated in data point boxes to prevent dust. We will not be creating a new box for rewarding each posting. Instead, the rewards will be accumulated in data-point boxes.
+5. When creating a data-point box, the pool box is not needed as data input. Creating a data-point will be decoupled from the pool, and will not require the bool box as data-input. 
+6. Update mechanism as before. We will have the same update mechanism as in v1.0
+7. Transferable participant tokens. Participant tokens are free to be transferred between public keys
+8. Longer epoch period (1 hour or 30 blocks).
+9. No separate funding box. The pool box emits only reward tokens and won't be handing out Ergs. Thus, there won't be a separate funding process required. 
+10. Reward mechanism separate from pool. The process of redeeming the reward tokens is not part of the protocol.
+
+## Reward Mechanism 
+
+In v1.0, the pool was responsbible for rewarding each participant for posting a data-point. In v2.0, the pool simply 
+certifies that a data-point was posted and a separate reward mechanism is proposed. This keeps the contract smaller and more flexible.
+
+The certificates are in the form of tokens emitted by the pool box. Once there are sufficient number of such tokens, a participant
+can exchange or burn them in return for a reward. We also give a sample token exchange contract. 
+
+**Note**: The reward mechanism needs more work. 
+Is there a need to lock the reward tokens and make them reedemable only by a certain contract?
+
+## Participant contract
+
+```scala
+{ // This box (participant box)
+  //   R4 data point
+  //   R5 box id of pool box
+  //   R6 public key 
+
+  //   tokens(0) participant token (one)
+  //   tokens(1) reward tokens collected (one or more) 
+  //   
+  //   When initializing the box, there must be one reward token. When claiming reward, one token must be left unclaimed
+
+  val poolNFT = fromBase64("ERERERERERERERERERERERERERERERERERERERERERE=") // TODO replace with actual 
+  val minStorageRent = 100000000
+  val selfPubKey = SELF.R6[GroupElement].get
+  val selfIndex = getVar[Int](0).get
+  val output = OUTPUTS(selfIndex)
+  val outPubKey = output.R6[GroupElement].get   // output must have a public key (not necessarily the same)
+
+  val isSimpleCopy = output.tokens(0) == SELF.tokens(0) && // participant token is preserved
+                     output.tokens(1)._1 == SELF.tokens(1)._1 && // reward tokenId is preserved
+                     output.tokens.size == 2 && // exactly two token types
+                     output.propositionBytes == SELF.propositionBytes && // script preserved
+                     output.R7[Any].isDefined == false // no more registers
+
+  val collection = INPUTS(0).tokens(0)._1 == poolNFT && // first input must be pool box
+                   output.tokens(1)._2 > SELF.tokens(1)._2 && // at least one reward token must be added 
+                   outPubKey == selfPubKey &&
+                   output.value >= SELF.value // nanoErgs value preserved
+
+  val owner = proveDlog(selfPubKey) &&
+              output.value >= minStorageRent
+
+  // owner can choose to transfer to another public key by setting different value in R6
+  isSimpleCopy && (owner || collection) 
+}
+```
+## Pool Contract
+
+```scala
+{ // This box (pool box)
+  //   R4 Current data point (Long)
+  //   epoch start height is stored in creation Height (R3)
+  // 
+  //   tokens(0) pool token (NFT)
+  //   tokens(1) reward tokens to be emitted (several) 
+  //   
+  //   When initializing the box, there must be one reward token. When claiming reward, one token must be left unclaimed
+  //   
+  
+  val participantTokenId = fromBase64("ERERERERERERERERERERERERERERERERERERERERERE=") // TODO replace with actual
+  val updateNFT = fromBase64("ERERERERERERERERERERERERERERERERERERERERERE=") // TODO replace with actual 
+  
+  val poolAction = if (getVar[Any](0).isDefined) {
+    val spenderIndex = getVar[Int](0).get // the index of the data-point box (NOT input!) belonging to spender    
+
+    val epochLength = 30 // 1 hour 
+    val minStartHeight = HEIGHT - epochLength
+    val minDataPoints = 4
+    val buffer = 4 
+    val rewardTokens = SELF.tokens(1)
+    val maxDeviationPercent = 5 // percent
+
+    def isValidDataPoint(b: Box) = if (b.R5[Any].isDefined) {
+      b.creationInfo._1    >= minStartHeight &&  // data point must not be too old
+      b.tokens(0)._1       == participantTokenId && // first token id must be of participant token
+      b.R5[Coll[Byte]].get == SELF.id // it must correspond to this epoch
+    } else false
+          
+    val dataPoints = INPUTS.filter(isValidDataPoint)    
+    val pubKey = dataPoints(spenderIndex).R6[GroupElement].get
+
+    val output = OUTPUTS(0)    
+
+    val enoughDataPoints = dataPoints.size >= minDataPoints    
+    val rewardEmitted = dataPoints.size * 2 // one extra token for each collected box as reward to collector   
+    val epochOver = SELF.creationInfo._1 <= minStartHeight
+       
+    val startData = 1L // we don't allow 0 data points
+    val startSum = 0L 
+    // we expected datapoints to be sorted in INCREASING order
+
+    val lastSortedSum = dataPoints.fold((startData, (true, startSum)), {
+        (t: (Long, (Boolean, Long)), b: Box) =>
+           val currData = b.R4[Long].get
+           val prevData = t._1
+           val wasSorted = t._2._1 
+           val oldSum = t._2._2
+           val newSum = oldSum + currData  // we don't have to worry about overflow, as it causes script to fail
+
+           val isSorted = wasSorted && prevData <= currData 
+
+           (currData, (isSorted, newSum))
+      }
+    )
+ 
+    val lastData = lastSortedSum._1
+    val isSorted = lastSortedSum._2._1
+    val sum = lastSortedSum._2._2
+    val average = sum / dataPoints.size 
+
+    val maxDelta = lastData * maxDeviationPercent / 100          
+    val firstData = dataPoints(0).R4[Long].get
+
+    sigmaProp(proveDlog(pubKey))                                 &&
+    enoughDataPoints                                             &&    
+    isSorted                                                     &&
+    lastData - firstData    <= maxDelta                          &&  
+    output.R4[Long].get     == average                           &&
+    output.tokens(0)        == SELF.tokens(0)                    && // pool NFT preserved
+    output.tokens(1)._1     == SELF.tokens(1)._1                 && // reward token id preserved
+    output.tokens(1)._2     == SELF.tokens(1)._2 - rewardEmitted && // reward token amount correctly reduced
+    output.tokens.size      == 2                                 && // no more tokens
+    output.propositionBytes == SELF.propositionBytes             && // script preserved
+    output.value            >= SELF.value                        && // Ergs preserved &&
+    output.creationInfo._1  >= HEIGHT - buffer                      // ensure that new box has correct start epoch height
+  } else false
+
+  val updateAction = INPUTS(0).tokens(0)._1 == updateNFT 
+  
+  poolAction || updateAction
+}
+```
+## Ballot Contract [WIP]
+
+```scala
+{ // This box (ballot box):
+  // R4 the group element of the owner of the ballot token [GroupElement]
+  // R5 dummy Int due to AOTC non-lazy evaluation (since pool box has Int at R5). Due to the line marked ****
+  // R6 the box id of the update box [Coll[Byte]]
+  // R7 the value voted for [Coll[Byte]]
+
+  // Base-64 version of the update NFT 720978c041239e7d6eb249d801f380557126f6324e12c5ba9172d820be2e1dde 
+  // Got via http://tomeko.net/online_tools/hex_to_base64.php
+  val updateNFT = fromBase64("ERERERERERERERERERERERERERERERERERERERERERE=") // TODO replace with actual 
+
+  val pubKey = SELF.R4[GroupElement].get
+  
+  val index = INPUTS.indexOf(SELF, 0)
+  
+  val output = OUTPUTS(index)
+  
+  val isBasicCopy = output.R4[GroupElement].get == pubKey && 
+                    output.propositionBytes == SELF.propositionBytes &&
+                    output.tokens == SELF.tokens && 
+                    output.value >= 10000000 // minStorageRent 
+  
+  sigmaProp(
+    isBasicCopy && (
+      proveDlog(pubKey) || (
+         INPUTS(0).tokens(0)._1 == updateNFT && 
+         output.value >= SELF.value
+      )
+    )
+  )
+}
+```
+
+## Update Contract [WIP]
+
+```scala
+{ // This box (update box):
+  // Registers empty 
+  // 
+  // ballot boxes (Inputs)
+  // R4 the pub key of voter [GroupElement] (not used here)
+  // R5 dummy int due to AOTC non-lazy evaluation (from the line marked ****)
+  // R6 the box id of this box [Coll[Byte]]
+  // R7 the value voted for [Coll[Byte]]
+
+  val poolNFT = fromBase64("ERERERERERERERERERERERERERERERERERERERERERE=") // TODO replace with actual 
+
+  val ballotTokenId = fromBase64("ERERERERERERERERERERERERERERERERERERERERERE=") // TODO replace with actual 
+
+  // collect and update in one step
+  val updateBoxOut = OUTPUTS(0) // copy of this box is the 1st output
+  val validUpdateIn = SELF.id == INPUTS(0).id // this is 1st input
+
+  val poolBoxIn = INPUTS(1) // pool box is 2nd input
+  val poolBoxOut = OUTPUTS(1) // copy of pool box is the 2nd output
+  
+  // compute the hash of the pool output box. This should be the value voted for
+  val poolBoxOutHash = blake2b256(poolBoxOut.propositionBytes)
+  
+  val validPoolIn = poolBoxIn.tokens(0)._1 == poolNFT
+  val validPoolOut = poolBoxIn.tokens == poolBoxOut.tokens && 
+                     poolBoxIn.value == poolBoxOut.value &&
+                     poolBoxIn.R4[Long].get == poolBoxOut.R4[Long].get &&
+                     poolBoxIn.R5[Int].get == poolBoxOut.R5[Int].get 
+
+  
+  val validUpdateOut = SELF.tokens == updateBoxOut.tokens && 
+                       SELF.propositionBytes == updateBoxOut.propositionBytes &&
+                       SELF.value >= updateBoxOut.value // ToDo: change in next update
+  // Above line contains a (non-critical) bug:
+  // Instead of 
+  //    SELF.value >= updateBoxOut.value
+  // we should have
+  //    updateBoxOut.value >= SELF.value
+  // 
+  // In the next oracle pool update, this should be fixed
+  // Until then, this has no impact because this box can only be spent in an update
+  // In summary, the next update will involve (at the minimum)
+  //    1. New update contract (with above bugfix)
+  //    2. New updateNFT (because the updateNFT is locked to this contract)
+
+  def isValidBallot(b:Box) = {
+    b.tokens.size > 0 && 
+    b.tokens(0)._1 == ballotTokenId &&
+    b.R6[Coll[Byte]].get == SELF.id && // ensure vote corresponds to this box ****
+    b.R7[Coll[Byte]].get == poolBoxOutHash // check value voted for
+  }
+  
+  val ballotBoxes = INPUTS.filter(isValidBallot)
+  
+  val votesCount = ballotBoxes.fold(0L, {(accum: Long, b: Box) => accum + b.tokens(0)._2})
+  
+  sigmaProp(validPoolIn && validPoolOut && validUpdateIn && validUpdateOut && votesCount >= 8) // minVotes = 8 
+}
+```


### PR DESCRIPTION
Main features in v2.0

1. Single pool address (only one type of box). This version of the pool will have only one address, the *pool address*. 
2. Data-point boxes will be considered as inputs rather than data-inputs. These inputs will be spent, and a copy of the box with the reward will be created.
3. Reward in tokens not Ergs. The posting reward will be in the form of tokens, which can be redeemed separately. 
4. Reward accumulated in data point boxes to prevent dust. We will not be creating a new box for rewarding each posting. Instead, the rewards will be accumulated in data-point boxes.
5. When creating a data-point box, the pool box is not needed as data input. Creating a data-point will be decoupled from the pool, and will not require the bool box as data-input. 
6. Update mechanism as before. We will have the same update mechanism as in v1.0
7. Transferable participant tokens. Participant tokens are free to be transferred between public keys
8. Longer epoch period (1 hour or 30 blocks).
9. No separate funding box. The pool box emits only reward tokens and won't be handing out Ergs. Thus, there won't be a separate funding process required. 
10. Reward mechanism separate from pool. The process of redeeming the reward tokens is not part of the protocol.