### PR TITLE
EIP-5: Added TreeVersion property and other updates

### DIFF
--- a/eip-0005.md
+++ b/eip-0005.md
@@ -51,19 +51,20 @@ here only for description of the corresponding content. Thus, the format is sche
 Binary serialization format is suitable for compact storage and wire transfers. All the
 fields are required (mandatory). 
 
-Field Name     |  Format            | Example                | Description
----------------|--------------------|------------------------|-----------
-`NameLength`   | `VLQ(UInt)`        | 18                     | Length of `Name` bytes (> 0)
-`Name`         | `Bytes`            | "rewardOutputScript"   | User readable name (non-empty string bytes in UTF-8 encoding)
-`DescLength`   | `VLQ(UInt)`        | 20                     | Length of `Description` bytes (>= 0)
-`Description`  | `Bytes`            | "holds mining rewards" | User readable contract description (string bytes in UTF-8 encoding)
-`ConstNum`     | `VLQ(UInt)`        | 2                      | Number of items in `ConstTypes` and `ConstValues` (>= 0)
-`ConstTypes`   | `Type*`            | (*)                    | `ConstNum` of constant types serialized (see _Type Serialization_ section of [ErgoTree Spec](https://ergoplatform.org/docs/ErgoTree.pdf)
-`ConstValues`  | `Opt[Opt[Data]*]`  | (**)                   | Optional. Either None or `ConstNum` number of data values serialized (see _Data Serialization_ section of [ErgoTree Spec](https://ergoplatform.org/docs/ErgoTree.pdf))
-`ParamNum`     | `VLQ(UInt)`        | 1                      | Number of named template parameters (>= 0)
-`Parameters`   | `Parameter*`       | minerPk: SigmaProp     | Typed template parameters (see [Parameter Serialization Format](#parameter-serialization-format) section below)
-`TemplateSize` | `VLQ(UInt)`        | 28                     | Size in bytes of the serialized `Template` field (> 0)
-`Template`     | `Expr`             | (***)                  | Contract Template bytes with ConstantPlaceholders (see _Expression Serialization_ section of [ErgoTree Spec](https://ergoplatform.org/docs/ErgoTree.pdf)
+Field Name     | Format            | Example               | Description
+---------------|-------------------|-----------------------|-----------
+`TreeVersion`  | `Opt[UByte]`      | 1                     | Optional version of ErgoTree which should be used
+`NameLength`   | `VLQ(UInt)`       | 18                    | Length of `Name` bytes (> 0)
+`Name`         | `Bytes`           | "rewardOutputScript"  | User readable name (non-empty string bytes in UTF-8 encoding)
+`DescLength`   | `VLQ(UInt)`       | 20                    | Length of `Description` bytes (>= 0)
+`Description`  | `Bytes`           | "holds mining rewards" | User readable contract description (string bytes in UTF-8 encoding)
+`ConstNum`     | `VLQ(UInt)`       | 2                     | Number of items in `ConstTypes` and `ConstValues` (>= 0)
+`ConstTypes`   | `Type*`           | (*)                   | `ConstNum` of constant types serialized (see _Type Serialization_ section of [ErgoTree Spec](https://ergoplatform.org/docs/ErgoTree.pdf)
+`ConstValues`  | `Opt[Opt[Data]*]` | (**)                  | Optional. Either None or `ConstNum` number of again optional default constant values serialized (see _Data Serialization_ section of [ErgoTree Spec](https://ergoplatform.org/docs/ErgoTree.pdf))
+`ParamNum`     | `VLQ(UInt)`       | 1                     | Number of named template parameters (>= 0)
+`Parameters`   | `Parameter*`      | minerPk: SigmaProp    | Typed template parameters (see [Parameter Serialization Format](#parameter-serialization-format) section below)
+`TemplateSize` | `VLQ(UInt)`       | 28                    | Size in bytes of the serialized `ExpressionTree` field (> 0)
+`ExpressionTree` | `Expr`            | (***)                 | Contract Template expression bytes with ConstantPlaceholders (see _Expression Serialization_ section of [ErgoTree Spec](https://ergoplatform.org/docs/ErgoTree.pdf)
 
 *Notes:*
 
@@ -78,15 +79,18 @@ serialized as Data format prefixed by 0 - if the value is `None`, and 1 - if the
 `Some(v)`. The `v` bytes follow immediately after the Some prefix. Thus, large constants
 can be omitted.
 
-- Some contracts may have `Template` field where all semantically significant constants
+- Some contracts may have `ExpressionTree` field where all semantically significant constants
 are not segregated. In most cases this is more compact and can be done by the compilers
 (e.g. [ErgoScala compiler](#notes-on-supporting-this-eip-in-ergotree-compilers)) where
 constant <-> parameter mapping is explicit. For such contracts the whole `ConstValues` field
 may be serialized as None.
 
-- `TemplateSize` field can be used to skip parsing `Template` when the contract template
-is embedded into some another format. Thus templates can be quickly scanned and the
-`Template` bytes obtained for hashing or template-based requests to the blockchain.
+- `TemplateSize` field can be used to skip parsing `ExpressionTree` when the contract template
+is embedded into some another format. Thus, templates can be quickly scanned and the
+`ExpressionTree` bytes can be obtained for hashing or template-based requests to the blockchain.
+
+- each ContractTemplate can be [converted to ErgoTree](#conversion-to-ergotree) of the
+  corresponding version (using `t.TreeVersion`)0
 
 _(*)_
 IR: 
@@ -134,10 +138,15 @@ Field Name     |  Format            | Example             | Description
 `Description`  | `Bytes`            | "miner's public key"| User readable parameter description (string bytes in UTF-8 encoding)
 `Placeholder`  | `VLQ(UInt)`        | 1                   | Placeholder index in ErgoTree.constants array 
 
-Note, the `Placeholder` field maps the parameters to the constants in the `Template`.
-More specifically, given a contract template `t` and and a parameter `p` inside `t` then
-`p.Placeholder` is an index in `t.ConstTypes` and `t.ConstValues`, such that `c = t.ConstValues(p.Placeholder)`.
-This also means that there is a placeholder in `t.Template` which also refers to `c`.
+Note, the `Placeholder` field maps the parameters to the constants in the `ExpressionTree`
+expression tree.
+More specifically, given a contract template `t: ContractTemplate` and a parameter `p:
+Parameter` inside `t` then `p.Placeholder` is an index in `t.ConstTypes` and
+`t.ConstValues`, such that `c = t.ConstValues(p.Placeholder)` is a value of the constant
+in `t.ExpressionTree` which has the index `p.Placeholder`.
+This also means that there is a placeholder in `t.ExpressionTree` which also refers to `c`
+as if it were in `constants` array of ErgoTree (i.e. we have `p.Placeholder == ph.index`
+for some ph in `t.ExpressionTree`).
 Note, that each value in `t.ConstValues` is optional, which means that for some parameters 
 the default value is not defined, however the type can always be looked up as 
 `t = t.ConstTypes(p.Placeholder)`.
@@ -161,19 +170,19 @@ of contract templates.
        "placeholder": 1
      }
   ],
-  "template": "ea02d192a39a8cc7a70173007301"
+  "templateTree": "ea02d192a39a8cc7a70173007301"
 }
 ```
 
 Notes:
-- The `constTypes` is required and the length of the array should be equal to
+- The `constTypes` property is required and the length of the array should be equal to
 `ConstNum`. Each element of `constTypes` is Base16 encoded bytes of the corresponding
 serialized type (see Type format in ErgoTree spec).
 - If `ConstValues` is None, then it can be omitted in JSON or equal to null. 
-  The length of `constValues` array should be equal to the length of `constTypes`.
-  Missing costants should be represented as null values in the array.
-  Every non-null value should be Base16 encoded string of constant value serialized as
-  Data format (see ErgoTree spec).
+  In non null, then the length of `constValues` array should be equal to the length of
+  `constTypes`. Missing constants should be represented as null values in the array.
+  Every non-null value in the array should be Base16 encoded string of constant value
+  serialized as Data format (see ErgoTree spec).
 
 ## Conversion to ErgoTree
 
@@ -182,10 +191,10 @@ table, where `t.name` means taking the corresponding field from the template `t`
 
 Field Name     |  Format            | Data Value             
 ---------------|--------------------|------------------------
-`Header`       | `UByte`            | 0x10                   
+`Header`       | `UByte`            | t.TreeVersion plus additional bits
 `ConstLength`  | `VLQ(UInt)`        | t.ConstNum          
 `Constants`    | `Const+`           | `Constants(i) = Constant(t.ConstTypes(i), t.ConstValues(i))`
-`Template`     | `Expr`             | t.Template             
+`Template`     | `Expr`             | t.ExpressionTree             
 
 The template parameters (see `t.Parameters`) can be used to substitute new values in the
 `Constants` thus redefining the default values of the template, or providing missing
@@ -223,7 +232,7 @@ ErgoTree.constants array) and use this mapping both in compilation of ErgoTree a
 generation of the template bytes. In particular, when creating ErgoTree bytes, the
 ErgoScala macros can do partial constant segregation, i.e. segregate only those constants
 from the expression tree which are mapped to the parameters leaving others in the tree.
-Thus created contract template will also satisfy an additional requirement, i.e. the number of
-constants will be the same as the number of parameters.
+Thus created contract template will also satisfy an additional requirement, i.e. the
+number of constants will be the same as the number of parameters.
 
 Similar algorithm can be used in the other ErgoTree compiler implementations.

--- a/eip-0005.md
+++ b/eip-0005.md
@@ -86,7 +86,7 @@ constant <-> parameter mapping is explicit. For such contracts the whole `ConstV
 may be serialized as None.
 
 - `TemplateSize` field can be used to skip parsing `ExpressionTree` when the contract template
-is embedded into some another format. Thus, templates can be quickly scanned and the
+is embedded into some other format. Thus, templates can be quickly scanned and the
 `ExpressionTree` bytes can be obtained for hashing or template-based requests to the blockchain.
 
 - each ContractTemplate can be [converted to ErgoTree](#conversion-to-ergotree) of the


### PR DESCRIPTION
We now have version 0 and 1 of ErgoTree on chain. 
With upcoming v5.0 and then v6.0 we will have even more versions. 
ErgoTree is interpreted according to the tree.version bits in its header. 
Thus, producing ErgoTree from contract template should respect the version, if it is specified.
