### PR TITLE
EIP3: Add section Export and import of public keys

### DIFF
--- a/eip-0003.md
+++ b/eip-0003.md
@@ -3,7 +3,7 @@ EIP-0003: Deterministic Wallet Standard
 
 * Author: gagarin55, Robert Kornacki
 * Created: 07-Oct-2019
-* Last edited: 23-Sept-2020
+* Last edited: 06-02-2022
 * License: CC0
 * Forking: not needed
 
@@ -59,3 +59,21 @@ As such all wallets supporting EIP-3 should have any change within a transaction
 This decision was made to simplify the experience for end users and solidify a cohesive standard for wallets to target in the Ergo ecosystem. A full blown privacy-preserving mixer is already available within the ecosystem, ErgoMix, and thus the pseudo-anonymity provided by internal addresses is not particularly vital.
 
 That said, in the future new wallets are more than welcome to create a new EIP for wallets which may wish to support internal addresses as well as an alternate standard (if valuable use cases arise).
+
+
+Export and import of public keys
+--------------------------------
+For showing wallets in another wallet application as read-only wallets, it is possible to export the extended public key. This way, all addresses can be derived while signing is not possible. For this to work, the derived key on path m / 44' / 429' / 0' / 0 needs to be used for export and import.
+
+The [BIP-0032](https://github.com/bitcoin/bips/blob/master/bip-0032.mediawiki#Serialization_format) defines a serialization format for keys that we can use here to export and import the xpubkey.
+
+Extended public keys are serialized as follows:
+
+    4 byte: version bytes (mainnet: 0x0488B21E; testnet: 0x043587CF)
+    1 byte: 4 (depth for our path m/44'/429'/0'/0)
+    4 bytes: the fingerprint of the parent's key (or 0x00000000 can be used as we don't validate on import)
+    4 bytes: 0x00000000 (child number)
+    32 bytes: the chain code
+    33 bytes: the public key key data
+    
+BIP-0032 leaves it open how this byte array should be encoded and suggests to use Base58 with a checksum. To not confuse Ergo xpubkeys with Bitcoin xpubkeys, we can use hex encoding instead.


### PR DESCRIPTION
This update of EIP-3 adds a section on how to serialize xpubkeys for import and export.

It could be discussed if we should really use a hex encoding without checksum. However, the described implementation is already used by Yoroi, Nautilus and [Ergo Paper Wallet](https://github.com/anon-br/ergo-paper-wallet) so we should just follow and document the state as it is here.

ergoplatform/ergo-appkit#128 adds support for Appkit.