### PR TITLE
EIP-21 add OpenAPI definition

### DIFF
--- a/eip-0021.md
+++ b/eip-0021.md
@@ -8,8 +8,8 @@
 
 ## Description 
 
-This EIP lists the common tokens of value with their unique identifier, 
-so users as well as wallet and explorer applications can verify if a token is genuine. The EIP is meant to be updated regularly when new tokens of value are added.
+This EIP defines a way for wallet applications, dApps and users to verify tokens. The EIP is meant to be updated regularly when new tokens of value or verification 
+services are added.
 
 ## Motivation 
 
@@ -24,11 +24,16 @@ identifier is equal to the identifier of the first input box of the transaction.
 As the box identifier is cryptographically unique, there's no chance to have the second token with the same identifier while the hash function being used 
 is collision-resistant. 
 
-In order to verify the authenticity of a token, the unique identifier of a token is needed to check.
+In order to verify the authenticity of a token, the unique identifier of a token abd its name is needed to check.
 
-## Process to add tokens to this list
-As outlined before, this list should only hold tokens of value. This means that mainly tokens of financial value can be added. Before opening a PR to add your token to this list, ask yourself if your token is interesting for scammers. When the answer is no, the token should probably not added to this list. 
-On rare occasions, tokens of a certain intrinsic value to the community could be added as well when there was a community vote with significant community participation.
+## Token authenticity verification algorithm
+
+The verification algorithm relies on a list of blocked tokens and a list of genuine tokens that can have a unique name.
+The token to test is checked as follows:
+- Is the token id listed in verified tokens? If yes, the token is **verified**.
+- Is the token id listed in blocked tokens? If yes, the token is **blocked**.
+- Is the token id not listed, but its name is the name of a verified token with unique name? If yes, the token is **suspicious**.
+- If nothing applies, the token authenticity is **unknown**.
 
 ## Recommended approach for applications showing tokens to end-users
 
@@ -49,7 +54,24 @@ Applications should show a warning sign next to tokens identified to be harmful 
 
 Proposed warning sign: [Material icons dangerous](https://fonts.google.com/icons?selected=Material%20Icons%20Outlined%3Adangerous%3A)
 
+## REST API services and OpenAPI specification
+
+The algorithm outlined before can be implemented in dApps/wallet applications, but this needs constant maintenance and slow updates to the users, so 
+REST API services are preferable to be used. Since verifying and blocking tokens means responsibility and providers of such services are free to add
+tokens to their lists as they wish, users should have the choice which service they want to use and what provider they trust the most. To give
+users a choice to switch and providers the ability to set up own services, an 
+[OpenAPI specification for a token verification service](eip-0021/openapi.yaml) 
+is attached to this EIP. API service providers must implement it completely.
+
 ## Token lists
+
+### Process to add tokens to this list
+
+As outlined before, this list should only hold tokens of value. This means that mainly tokens of financial value can be added. Before opening a PR to add your token to
+this list, ask yourself if your token is interesting for scammers. When the answer is no, the token should probably not added to this list.
+On rare occasions, tokens of a certain intrinsic value to the community could be added as well when there was a community vote with significant community participation.
+Applications and REST API service providers can add own tokens to their list, but should be open about it. As Ergo is neutral, the list defined here should be 
+compact and the smallest common denominator.
 
 ### Genuine tokens
 

--- a/eip-0021.md
+++ b/eip-0021.md
@@ -24,7 +24,7 @@ identifier is equal to the identifier of the first input box of the transaction.
 As the box identifier is cryptographically unique, there's no chance to have the second token with the same identifier while the hash function being used 
 is collision-resistant. 
 
-In order to verify the authenticity of a token, the unique identifier of a token abd its name is needed to check.
+In order to verify the authenticity of a token, the unique identifier of a token and its name is needed to check.
 
 ## Token authenticity verification algorithm
 

--- a/eip-0021.md
+++ b/eip-0021.md
@@ -63,6 +63,8 @@ users a choice to switch and providers the ability to set up own services, an
 [OpenAPI specification for a token verification service](eip-0021/openapi.yaml) 
 is attached to this EIP. API service providers must implement it completely.
 
+A reference implementation can be found here: https://github.com/MrStahlfelge/eip21-backend-reference
+
 ## Token lists
 
 ### Process to add tokens to this list

--- a/eip-0021/openapi.yaml
+++ b/eip-0021/openapi.yaml
@@ -1,0 +1,99 @@
+openapi: 3.0.1
+info:
+  title: Ergo Platform Genuine Tokens Verification
+  description: 'See [EIP-21](https://github.com/ergoplatform/eips/blob/master/eip-0021.md) for full information'
+  license:
+    name: Apache 2.0
+    url: http://www.apache.org/licenses/LICENSE-2.0.html
+  version: 1.0.0
+tags:
+  - name: tokenVerification
+    description: APIs implementing EIP-21
+    externalDocs:
+      description: EIP-21
+      url: https://github.com/ergoplatform/eips/blob/master/eip-0021.md
+paths:
+  /tokens/check/{tokenId}/{tokenName}:
+    get:
+      tags:
+        - tokenVerification
+      summary: Check a token verification
+      operationId: checkToken
+      parameters:
+        - name: tokenId
+          in: path
+          description: ID of token to return
+          required: true
+          schema:
+            type: string
+        - name: tokenName
+          in: path
+          description: ID of token to return
+          required: true
+          schema:
+            type: string
+      responses:
+        200:
+          description: successful operation
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/CheckResponse'
+  /tokens/listGenuine:
+    get:
+      tags:
+        - tokenVerification
+      summary: Lists all genuine tokens known
+      operationId: listGenuine
+      responses:
+        200:
+          description: successful operation
+          content:
+            application/json:
+              schema:
+                type: array
+                items:
+                  $ref: '#/components/schemas/GenuineToken'
+  /tokens/listBlocked:
+    get:
+      tags:
+        - tokenVerification
+      summary: Lists all blocked tokens
+      operationId: listBlocked
+      responses:
+        200:
+          description: successful operation
+          content:
+            application/json:
+              schema:
+                type: array
+                items:
+                  type: string
+
+
+components:
+  schemas:
+    CheckResponse:
+      type: object
+      properties:
+        genuine:
+          type: integer
+          description: Flag with 0 unknown, 1 verified, 2 suspicious, 3 blocked (see EIP-21)
+          format: int32
+        token:
+          anyOf:
+            - $ref: '#/components/schemas/GenuineToken'
+          nullable: true
+    GenuineToken:
+      type: object
+      properties:
+        tokenId:
+          type: string
+        tokenName:
+          type: string
+        uniqueName:
+          type: boolean
+        issuer:
+          type: string
+          nullable: true
+


### PR DESCRIPTION
This adds an OpenAPI definiton file and some more specifications to EIP-21.

Goal is to make it possible for ecosystem supporters to create standardized API services to verify tokens which can be used by dApps and users can set up to use in their wallet applications.