### PR TITLE
EIP-4 add utility asset type

### DIFF
--- a/eip-0004.md
+++ b/eip-0004.md
@@ -54,5 +54,7 @@ The standardization of various asset types can be found below:
 | NFT - audio artwork              | [0x01, 0x02] - i.e., "0e020102"                        | SHA256 hash of the audio    | Optional - link to the audio encoded as Coll[Byte] or (link to the audio, link to the image cover) encoded as (Coll[Byte], Coll[Byte]) (UTF-8 representation) |
 | NFT - video artwork              | [0x01, 0x03] - i.e., "0e020103"                        | SHA256 hash of the video    | Optional - link to the video (UTF-8 representation) |
 | [Membership token - threshold signature](https://www.ergoforum.org/t/a-simpler-collective-spending-approach-for-everyone/476)              | [0x02, 0x01] - i.e., "0e020201"                        | Number of required signatures (Integer) - i.e., 4 in case of 4-of-10 threshold signature   | Deposit address of the funds controlled by the threshold signature (Ergo tree byte array) |
+| Utility - NFT (i.e. a key used to unlock funds in P2S address) | [0x03, 0x01] - i.e., "0e020301" | Optional | Optional |
+| Utility - Token (i.e. LP tokens on a dex) | [0x03, 0x02] - i.e., "0e020302" | Optional | Optional | 
 
 The above registers (R7-R9) are also encoded as Coll[Byte] type unless stated otherwise.


### PR DESCRIPTION
Will allow for wallets and dapps to filter utility tokens and nft to make it easier for the user to keep an overview.