### PR TITLE
Proper link to EIP-27 in TOC

### DIFF
--- a/README.md
+++ b/README.md
@@ -19,4 +19,4 @@ Please check out existing EIPs, such as [EIP-1](eip-0001.md), to understand the 
 | [EIP-0022](eip-0022.md) | Auction Contract |
 | [EIP-0024](eip-0024.md) | Artwork contract |
 | [EIP-0025](eip-0025.md) | Payment Request URI |
-| [EIP-0027](eip-0025.md) | Emission Retargeting Soft-Fork |
+| [EIP-0027](eip-0027.md) | Emission Retargeting Soft-Fork |


### PR DESCRIPTION
In #52 , TOC link to EIP-27 is wrongly linking to EIP-25 in fact

Fixed in this PR 