### PR TITLE
eip4 - 3d Model Asset Type

### DIFF
--- a/eip-0004.md
+++ b/eip-0004.md
@@ -53,6 +53,8 @@ The standardization of various asset types can be found below:
 | NFT - picture artwork              | [0x01, 0x01] - i.e., "0e020101"                        | SHA256 hash of the picture    | Optional - link to the artwork (UTF-8 representation) |
 | NFT - audio artwork              | [0x01, 0x02] - i.e., "0e020102"                        | SHA256 hash of the audio    | Optional - link to the audio encoded as Coll[Byte] or (link to the audio, link to the image cover) encoded as (Coll[Byte], Coll[Byte]) (UTF-8 representation) |
 | NFT - video artwork              | [0x01, 0x03] - i.e., "0e020103"                        | SHA256 hash of the video    | Optional - link to the video (UTF-8 representation) |
+| NFT - 3d model artwork              | [0x01, 0x04] - i.e., "0e020104"                        | SHA256 hash of the 3d model    | Optional - link to the 3d model encoded as Coll[Byte] or (link to the 3d model, link to the image cover) encoded as (Coll[Byte], Coll[Byte]) (UTF-8 representation) |
 | [Membership token - threshold signature](https://www.ergoforum.org/t/a-simpler-collective-spending-approach-for-everyone/476)              | [0x02, 0x01] - i.e., "0e020201"                        | Number of required signatures (Integer) - i.e., 4 in case of 4-of-10 threshold signature   | Deposit address of the funds controlled by the threshold signature (Ergo tree byte array) |
+
 
 The above registers (R7-R9) are also encoded as Coll[Byte] type unless stated otherwise.

--- a/eip-0004.md
+++ b/eip-0004.md
@@ -56,5 +56,4 @@ The standardization of various asset types can be found below:
 | NFT - 3d model artwork              | [0x01, 0x04] - i.e., "0e020104"                        | SHA256 hash of the 3d model    | Optional - link to the 3d model encoded as Coll[Byte] or (link to the 3d model, link to the image cover) encoded as (Coll[Byte], Coll[Byte]) (UTF-8 representation) |
 | [Membership token - threshold signature](https://www.ergoforum.org/t/a-simpler-collective-spending-approach-for-everyone/476)              | [0x02, 0x01] - i.e., "0e020201"                        | Number of required signatures (Integer) - i.e., 4 in case of 4-of-10 threshold signature   | Deposit address of the funds controlled by the threshold signature (Ergo tree byte array) |
 
-
 The above registers (R7-R9) are also encoded as Coll[Byte] type unless stated otherwise.


### PR DESCRIPTION
Simple addition to eip4 to include 3d models.
Similar to audio files, 3d models may require a cover image as seen in R9. 