### PR TITLE
EIP4 - NFT File Attachment Asset Type

### DIFF
--- a/eip-0004.md
+++ b/eip-0004.md
@@ -67,7 +67,7 @@ An NFT File Attachment should have a multi-attachment content type as per the [E
 - Attachment 2 (Optional): `contentType = 2` (plain text) - Link to the second file (the sha256 hash of this file should be in index 1 of R8 and the file extension should be given as the second file extenstion in attachment 0)
 - Attachment *n* (Optional): `contentType = 2` (plain text) - Link to the *n*th file (the sha256 hash of this file should be in index `n-1` of R8 and the file extension should be given as the *n*th file extenstion in attachment 0)
 
-**NFT File Attachment Examples**
+**NFT File Attachment Example**
 
 Files to be attached:
 | File Format        | File Link                                     | File Hash                      |

--- a/eip-0004.md
+++ b/eip-0004.md
@@ -61,7 +61,7 @@ The above registers (R7-R9) are also encoded as Coll[Byte] type unless stated ot
 ### NFT File Attachments
 NFT File attachments can be used to attach any number of files of any file format to an Ergo token.
 
-An NFT File Attachment should have a multi-attachment content type as per the EIP-29 Standard, with the following structure:
+An NFT File Attachment should have a multi-attachment content type as per the [EIP-29 Standard](https://github.com/ergoplatform/eips/pull/58), with the following structure:
 - Attachment 0: `contentType = 2` (plain text) - Comma seperated list of file formats of the attached files
 - Attachment 1: `contentType = 2` (plain text) - Link to the first file (the sha256 hash of this file should be in index 0 of R8 and the file extension should be given as the first file extenstion in attachment 0)
 - Attachment 2 (Optional): `contentType = 2` (plain text) - Link to the second file (the sha256 hash of this file should be in index 1 of R8 and the file extension should be given as the second file extenstion in attachment 0)

--- a/eip-0004.md
+++ b/eip-0004.md
@@ -53,7 +53,7 @@ The standardization of various asset types can be found below:
 | NFT - picture artwork              | [0x01, 0x01] - i.e., "0e020101"                        | SHA256 hash of the picture    | Optional - link to the artwork (UTF-8 representation) |
 | NFT - audio artwork              | [0x01, 0x02] - i.e., "0e020102"                        | SHA256 hash of the audio    | Optional - link to the audio encoded as Coll[Byte] or (link to the audio, link to the image cover) encoded as (Coll[Byte], Coll[Byte]) (UTF-8 representation) |
 | NFT - video artwork              | [0x01, 0x03] - i.e., "0e020103"                        | SHA256 hash of the video    | Optional - link to the video (UTF-8 representation) |
-| NFT - File Attachments             | [0x01, 0xFF] - i.e., "0e0201FF"                        | Collection of SHA256 hashes of the files encoded as Coll[Coll[Byte]]    | NFT File Attachment (see encoding below) |
+| NFT - File Attachments             | [0x01, 0x0F] - i.e., "0e02010F"                        | Collection of SHA256 hashes of the files encoded as Coll[Coll[Byte]]    | NFT File Attachment (see encoding below) |
 | [Membership token - threshold signature](https://www.ergoforum.org/t/a-simpler-collective-spending-approach-for-everyone/476)              | [0x02, 0x01] - i.e., "0e020201"                        | Number of required signatures (Integer) - i.e., 4 in case of 4-of-10 threshold signature   | Deposit address of the funds controlled by the threshold signature (Ergo tree byte array) |
 
 The above registers (R7-R9) are also encoded as Coll[Byte] type unless stated otherwise.

--- a/eip-0004.md
+++ b/eip-0004.md
@@ -62,8 +62,25 @@ The above registers (R7-R9) are also encoded as Coll[Byte] type unless stated ot
 NFT File attachments can be used to attach any number of files of any file format to an Ergo token.
 
 An NFT File Attachment should have a multi-attachment content type as per the EIP-29 Standard, with the following structure:
-- Attachment 0: 
-- Attachment 1: 
+- Attachment 0: `contentType = 2` (plain text) - Comma seperated list of file formats of the attached files
+- Attachment 1: `contentType = 2` (plain text) - Link to the first file (the sha256 hash of this file should be in index 0 of R8 and the file extension should be given as the first file extenstion in attachment 0)
+- Attachment 2 (Optional): `contentType = 2` (plain text) - Link to the second file (the sha256 hash of this file should be in index 1 of R8 and the file extension should be given as the second file extenstion in attachment 0)
+- Attachment *n* (Optional): `contentType = 2` (plain text) - Link to the *n*th file (the sha256 hash of this file should be in index `n-1` of R8 and the file extension should be given as the *n*th file extenstion in attachment 0)
+
+**NFT File Attachment Examples**
+
+Files to be attached:
+| File Format        | File Link                                     | File Hash                      |
+| :---------------: |:-----------------------------------------------:| :----------------------------:|
+| glb            |`ipfs://link1`|`c5286e4a262c0a25e776124bfb09a961bfb6daf20b95fc201d2ac06b3134c199`|
+| png             | `ipfs://link2`                 |  `eb56a7800112669108ef13b1e8bd2c00e3941775f0b5a6dcb091606e649146f3` | `bbfcfc944bffd3fe35cd94b44f5df2e96685baf27856a89fba29263b72469356`    | 
+| png           | `ipfs://link3` | `39abad7b6e825b93d708b300434971fb62353441fd8690fa5596faa57a02cbf5`    | 
+
+Registers (Rendered Values):
+| R7        | R8                                    | R9                      |
+| :---------------: |:-----------------------------------------------:| :----------------------------:|
+| `0201FF`    |[`c5286e4a262c0a25e776124bfb09a961bfb6daf20b95fc201d2ac06b3134c199`, `bbfcfc944bffd3fe35cd94b44f5df2e96685baf27856a89fba29263b72469356`, `39abad7b6e825b93d708b300434971fb62353441fd8690fa5596faa57a02cbf5`]                 |  (`505250`, ( `1`,[<br>(`2`,`676C622C706E672C706E67`),<br>(`2`, `697066733A2F2F6C696E6B31`),<br>(`2`, `697066733A2F2F6C696E6B32`),(`2`, `697066733A2F2F6C696E6B33`)] )    |
+
 
 
 

--- a/eip-0004.md
+++ b/eip-0004.md
@@ -53,6 +53,17 @@ The standardization of various asset types can be found below:
 | NFT - picture artwork              | [0x01, 0x01] - i.e., "0e020101"                        | SHA256 hash of the picture    | Optional - link to the artwork (UTF-8 representation) |
 | NFT - audio artwork              | [0x01, 0x02] - i.e., "0e020102"                        | SHA256 hash of the audio    | Optional - link to the audio encoded as Coll[Byte] or (link to the audio, link to the image cover) encoded as (Coll[Byte], Coll[Byte]) (UTF-8 representation) |
 | NFT - video artwork              | [0x01, 0x03] - i.e., "0e020103"                        | SHA256 hash of the video    | Optional - link to the video (UTF-8 representation) |
+| NFT - File Attachments             | [0x01, 0xFF] - i.e., "0e0201FF"                        | Collection of SHA256 hashes of the files encoded as Coll[Coll[Byte]]    | NFT File Attachment (see encoding below) |
 | [Membership token - threshold signature](https://www.ergoforum.org/t/a-simpler-collective-spending-approach-for-everyone/476)              | [0x02, 0x01] - i.e., "0e020201"                        | Number of required signatures (Integer) - i.e., 4 in case of 4-of-10 threshold signature   | Deposit address of the funds controlled by the threshold signature (Ergo tree byte array) |
 
 The above registers (R7-R9) are also encoded as Coll[Byte] type unless stated otherwise.
+
+### NFT File Attachments
+NFT File attachments can be used to attach any number of files of any file format to an Ergo token.
+
+An NFT File Attachment should have a multi-attachment content type as per the EIP-29 Standard, with the following structure:
+- Attachment 0: 
+- Attachment 1: 
+
+
+


### PR DESCRIPTION
Adding NFT File Attachments to eip4 asset types.
File Attachments can be used to attach an arbitrary collection of files to an NFT.
Benefits of this eip:
- Every new file format can use NFT file attachments and circumvent the need to create a new pull request to eip4 just to add a asset type
- Artists can provide authentic copies of additional files to an NFT (such as a cover photo, or bonus files)