### PR TITLE
EIP-20 fix wrong field name replyToUrl

### DIFF
--- a/eip-0020.md
+++ b/eip-0020.md
@@ -101,7 +101,7 @@ or using Cold Wallet and EIP-0019 protocol. The result of signing is
 `SignedTransaction` data.
 
 8) The Hot Wallet obtains the transaction id and sends it to the dApp using
-`ErgoPayTransactionSent` API post message to `replyToUrl` if the url is provided, if
+`ErgoPayTransactionSent` API post message to `replyTo` url if it is provided, if
 successful the wallet then submits `SignedTransaction` to the blockchain. If the url is
 not provided, then the wallet submits the transaction to blockchain without notifying the
 dApp. The dApp can monitor the blockchain by txId which it can learn from
@@ -160,7 +160,7 @@ ErgoPaySigningRequest:
   - address: String (optional)
   - message: String (optional*)
   - messageSeverity: String (optional) "INFORMATION", "WARNING", "ERROR"
-  - replyToUrl: String (optional)
+  - replyTo: String (optional)
 ```
 
 Either a **transaction** or a **message** must be provided, otherwise the request is invalid.
@@ -176,7 +176,7 @@ If **address** is provided by the dApp, the wallet can preselect the key the use
 needs to sign the transaction.
 
 After signing is performed and the `SignedTransaction` data is obtained, the 
-wallet can POST the following data to the dApp using **replyToUrl** from the
+wallet can POST the following data to the dApp using url in **replyTo** field from the
 signing request (json format) if it is provided. 
 
 ```
@@ -199,7 +199,7 @@ also be encoded in the QR code or link:
 
 `ergopay:<ReducedTransaction, base 64 url safe encoded>`
 
-It is not possible to provide **description**, **address**, **message** and **replyToUrl** in this simpler
+It is not possible to provide **description**, **address**, **message** and **replyTo** url in this simpler
 interchange format.
 
 dApp developers should keep in mind that there are length restrictions for URI schemes


### PR DESCRIPTION
The field name `replyToUrl` was named `replyTo` in practice [Source](https://github.com/ergoplatform/ergo-wallet-app/blob/432ee752a08172ec3183551332c789c4fad3ecb8/common-jvm/src/main/java/org/ergoplatform/transactions/ErgoPay.kt#L101)

This fixes the documentation.