### PR TITLE
[EIP-0023] In update contract check reward tokens are either preserved or voted by ballot boxes

### DIFF
--- a/eip-0023/eip-0023.md
+++ b/eip-0023/eip-0023.md
@@ -143,7 +143,7 @@ Before going into the transactions in the protocol, we first present the contrac
 - [Refresh Contract](contracts/refresh_contract.es) `cs5c5QEirstI4ZlTyrbTjlPwWYHRW+QsedtpyOSBnH4=`
 - [Oracle Contract](contracts/oracle_contract.es) `fhOYLO3s+NJCqTQDWUz0E+ffy2T1VG7ZnhSFs0RP948=`
 - [Ballot Contract](contracts/ballot_contract.es) `2DnK+72bh+TxviNk8XfuYzLKtuF5jnqUJOzimt30NvI=`
-- [Update Contract](contracts/update_contract.es) `3aIVTP5tRgCZHxaT3ZFw3XubRV5DJi0rKeo9bKVHlVw=`
+- [Update Contract](contracts/update_contract.es) `pQ7Dgjq1pUyISroP+RWEDf+kVNYAWjeFHzW+cpImhsQ=`
 Use this Scastie playground to calculate the above hashes - [https://scastie.scala-lang.org/hnTEm2lJQPG1wRYCqPz8LQ](https://scastie.scala-lang.org/hnTEm2lJQPG1wRYCqPz8LQ)
 ## Transactions
 


### PR DESCRIPTION
As discovered in https://github.com/ergoplatform/oracle-core/issues/173 :
>In their votes, an oracle must specify the reward token amount in the pool box when the update-pool command is initiated. So if the update-pool command is not planned to run in the current epoch, the oracles have to estimate the reward token amount in the pool box in the upcoming epochs. Since the reward tokens are given only to the posting oracles whose data points are within the deviation range, it is pretty hard to precisely estimate the reward tokens amount in the pool box in a few epochs, let alone the next day. This effectively makes the whole prepare-update, vote-update-pool, update-pool process to be run in the shortest time possible, ideally within one epoch. I foresee this would be challenging in a decentralized environment.

What if we request the reward token id and amount from voters and check that the new pool box has it only when a new reward token is minted? Otherwise, check that the reward token is preserved in the update contract.
The whole check could be expressed as "reward tokens in the new pool box should be preserved (poolIn==poolOut) OR exactly as voted for (reward token id and amount in ballot box registers)".