### PR TITLE
Rename Placeholder to ConstantIndex in EIP-5

### DIFF
--- a/eip-0005.md
+++ b/eip-0005.md
@@ -130,26 +130,26 @@ field). This is because some constant values may not be changed without breaking
 logic and hence they cannot be used as template parameters. This depends on the contract,
 the format supports all the necessary combinations.
 
-Field Name     |  Format            | Example             | Description
----------------|--------------------|---------------------|-----------
-`NameLength`   | `VLQ(UInt)`        | 7                   | Length of `Name` bytes 
-`Name`         | `Bytes`            | "minerPk"           | User readable parameter name (string bytes in UTF-8 encoding)
-`DescLength`   | `VLQ(UInt)`        | 18                  | Length of `Description` bytes 
-`Description`  | `Bytes`            | "miner's public key"| User readable parameter description (string bytes in UTF-8 encoding)
-`Placeholder`  | `VLQ(UInt)`        | 1                   | Placeholder index in ErgoTree.constants array 
+Field Name      |  Format            | Example             | Description
+----------------|--------------------|---------------------|-----------
+`NameLength`    | `VLQ(UInt)`        | 7                   | Length of `Name` bytes 
+`Name`          | `Bytes`            | "minerPk"           | User readable parameter name (string bytes in UTF-8 encoding)
+`DescLength`    | `VLQ(UInt)`        | 18                  | Length of `Description` bytes 
+`Description`   | `Bytes`            | "miner's public key"| User readable parameter description (string bytes in UTF-8 encoding)
+`ConstantIndex` | `VLQ(UInt)`        | 1                   | Index in the ErgoTree.constants array 
 
-Note, the `Placeholder` field maps the parameters to the constants in the `ExpressionTree`
+Note, the `ConstantIndex` field maps the parameters to the constants in the `ExpressionTree`
 expression tree.
 More specifically, given a contract template `t: ContractTemplate` and a parameter `p:
-Parameter` inside `t` then `p.Placeholder` is an index in `t.ConstTypes` and
-`t.ConstValues`, such that `c = t.ConstValues(p.Placeholder)` is a value of the constant
-in `t.ExpressionTree` which has the index `p.Placeholder`.
+Parameter` inside `t` then `p.ConstantIndex` is an index in `t.ConstTypes` and
+`t.ConstValues`, such that `c = t.ConstValues(p.ConstantIndex)` is a value of the constant
+in `t.ExpressionTree` which has the index `p.ConstantIndex`.
 This also means that there is a placeholder in `t.ExpressionTree` which also refers to `c`
-as if it were in `constants` array of ErgoTree (i.e. we have `p.Placeholder == ph.index`
+as if it were in `constants` array of ErgoTree (i.e. we have `p.ConstantIndex == ph.index`
 for some ph in `t.ExpressionTree`).
 Note, that each value in `t.ConstValues` is optional, which means that for some parameters 
 the default value is not defined, however the type can always be looked up as 
-`t = t.ConstTypes(p.Placeholder)`.
+`t = t.ConstTypes(p.ConstantIndex)`.
 
 ## JSON Format
 
@@ -167,7 +167,7 @@ of contract templates.
      { 
        "name": "minerPk",
        "description": "miner's public key",
-       "placeholder": 1
+       "constantIndex": 1
      }
   ],
   "templateTree": "ea02d192a39a8cc7a70173007301"
@@ -203,7 +203,7 @@ constant values.
 Note, ErgoTree composition from a template doesn't require an implementation of all the
 ErgoTree serializers. Only Type Serializer and DataSerializer (see ErgoTree Specification)
 have to be implemented to parse and serialize `ConstTypes` and `ConstValues` bytes,
-replace the necessary constants (using `Placeholder` field of the parameter) and then
+replace the necessary constants (using `ConstantIndex` field of the parameter) and then
 serialize the updated array of the constants back to the new bytes array.
 
 This relaxed requirement, will significantly simplify composition of valid ErgoTrees from


### PR DESCRIPTION
Per discussion on https://github.com/ScorexFoundation/sigmastate-interpreter/pull/857#discussion_r1120791012, it makes more sense to call the field `ConstantIndex` since there is a concept of `ConstantPlaceholder` in ErgoTree already which can conflict with this notion of `Placeholder`.