### PR TITLE
EIP-43: Reduced Transaction

### DIFF
--- a/README.md
+++ b/README.md
@@ -23,3 +23,4 @@ Please check out existing EIPs, such as [EIP-1](eip-0001.md), to understand the 
 | [EIP-0031](eip-0031.md) | Babel Fees |
 | [EIP-0034](eip-0034.md) | NFT Collection Standard |
 | [EIP-0039](eip-0039.md) | Monotonic box creation height rule |
+| [EIP-0043](eip-0043.md) | Reduced Transaction                |

--- a/eip-0019.md
+++ b/eip-0019.md
@@ -58,85 +58,17 @@ which we describe in [Reference Implementation](#reference-implementation)
 section.
 
 In the following sections we:
- 1) describe the main problem we need to solve; 
- 2) describe a solution;  
- 3) specify a protocol with two roles: HotWallet and
-ColdWallet which must be implemented by complying Wallet applications and 
- 4) describe a reference implementation of both Hot and Cold roles in [Ergo Wallet
-for Android](https://github.com/MrStahlfelge/ergo-wallet-android).
-
-## Cold Signing Problem
-
-In the Ergo's eUTXO model a box can be protected by an arbitrary complex
-contract (aka spending condition) and the spending transaction should satisfy
-that condition by adding required context variables, creating expected number of
-outputs with specific registers etc. i.e. a special data structure called
-`Context`. The Context should be created for each input of the transaction
-and then passed to the Prover which will generate a signature for that input.
-See [general overview of signing and
-verification](https://github.com/ScorexFoundation/sigmastate-interpreter#sigma-language-background)
-process in Ergo for details.
-
-In general, the Context represents the current state of the blockchain and
-includes current header, previous 10 headers, current height etc. This data can
-be retrieved from blockchain nodes. This is possible on Hot Wallet device, but
-is not possible on Cold Wallet device (there is no network connection).
-
-At the same time the prover need to know both the Context data and the private
-keys, which are stored on the Cold Wallet device, and so the Prover must run on
-the Cold Wallet device.
-
-And finally, which is the problem, we cannot transfer unsigned transaction along
-with all the contexts for each input to the Cold Wallet via QR code. 
-
-QR codes have limit of 4K bytes on the maximum size of serialized data. Most of
-the transactions with required Contexts will exceed this limit.
+ 1) describe a solution;  
+ 2) specify a protocol with two roles: HotWallet and ColdWallet which must be implemented
+ by complying Wallet applications and
+ 3) describe a reference implementation of both Hot and Cold roles in [Ergo Wallet
+App](https://github.com/ergoplatform/ergo-wallet-app).
 
 ## Simplified Signing using ReducedTransaction
 
-To solve the problem of _cold signing_ we need a new data structure and
-serialization format called `ReducedTransaction`.
-
-```
-ReducedTransaction:
-  - unsignedTx: UnsignedTransaction
-  - reducedInputs: Seq[ReducedInputData]
-  - txCost: Int
-
-UnsignedTransaction:
-  - inputs: Seq[UnsignedInput],
-  - dataInputs: Seq[DataInput],
-  - outputCandidates: Seq[ErgoBoxCandidate]
-
-UnsignedInput:
-  - boxId: BoxId
-  - extension: ContextExtension
-```
-
-ReducedInputData:
-  - reductionResult: ReductionResult 
-Thus, the `ReducedTransaction` instance contains unsigned transaction augmented with
-one `ReductionResult` for each `UnsignedInput`. 
-
-```
-ReductionResult:
-  - value: SigmaBoolean
-  - cost: Long
-```
-
-Note that `UnsignedInput` object doesn't contain `ergoTree`, `additionalTokens`,
-`additionalRegisters` and other properties of
-[ErgoBox](https://github.com/ScorexFoundation/sigmastate-interpreter/blob/4533b6a7ae86ada20f3136c70a67a920ae7c43e1/sigmastate/src/main/scala/org/ergoplatform/ErgoBox.scala#L51)
-which are necessary to perform
-[ErgoTree](https://github.com/ScorexFoundation/sigmastate-interpreter/blob/1a1b003bc30e490d8b5af30e7670227e54e682c2/sigmastate/src/main/scala/sigmastate/Values.scala#L1014)
-reduction and which are part of the
-[Context](https://github.com/ScorexFoundation/sigmastate-interpreter/blob/e5127f6743db824f7280881cd5c4ecd336075e2f/sigmastate/src/main/scala/org/ergoplatform/ErgoLikeContext.scala#L51)
-data structure required by the
-[prove](https://github.com/ScorexFoundation/sigmastate-interpreter/blob/f24833d8d4572d77e4a93e5b69360335cb2d7dc1/sigmastate/src/main/scala/sigmastate/interpreter/ProverInterpreter.scala#L104)
-method.
-
-This is because those context data is not required to generate proof (aka signature)
-once ErgoTree is reduced to ReductionResult containing sigma proposition.
+In order to overcome the problem of Context size we can rely on the ability of Ergo
+provers to reduce transaction without signing it. The result of such reduction is a data
+structure called [ReducedTransaction](eip-0043.md).
 
 Having the `ReducedTransaction` data structure the full transaction signing
 consists of three steps
@@ -170,7 +102,7 @@ val signedTx = prover.signReduced(reducedTx)
 
 It is important to note, that signatures for all inputs of the ReducedTransaction
 can be generated directly, without script evaluation (aka script reduction) and
-and thus, Cold Wallet don't need complex spending contexts.
+thus, Cold Wallet don't need complex spending contexts.
 
 ## Transaction Interchange
 

--- a/eip-0043.md
+++ b/eip-0043.md
@@ -105,6 +105,7 @@ names are not serialized.
 | `messageSize`   | `VLQ(UInt)`         | Number of bytes in the messageToSign of the transaction |
 | `messageToSign` | `Bytes`             | serialized bytes of the unsignedTx.messageToSign  |
 | `reducedInputs` | `ReductionResult*` | serialized reduced inputs                         |
+| `txCost`        | `VLQ(UInt)`        | transaction cost according to the prover          |
 
 Note, the number of reduced inputs is serialized as part of the `messageToSign`.
 

--- a/eip-0043.md
+++ b/eip-0043.md
@@ -1,0 +1,129 @@
+# EIP-43: Reduced Transaction 
+
+* Author: @aslesarenko
+* Status: Proposed
+* Created: 18-August-2021
+* License: CC0
+* Forking: not needed
+
+## Contents
+- [Description](#description)
+- [Background And Motivation](#background-and-motivation)
+- [Reduced Transaction data](#reduced-transaction-data)
+- [Data Formats](#data-formats)
+- [Reference implementation](#implementation-in-appkit)
+
+## Description
+This EIP defines a data format for Reduced Transaction which can be used:
+- to enable interoperation between an online dApp and a wallet app for creating, signing and sending Ergo transactions
+- to serialize reduced transaction to QR code for scanning by a wallet app
+- to serialize reduced transaction to JSON for using in Ergo node API
+
+## Background And Motivation
+
+In the Ergo's eUTXO model a box can be protected by an arbitrary complex
+contract (aka spending condition) and the spending transaction should satisfy
+that condition by adding required context variables, creating expected number of
+outputs with specific registers etc. i.e. a special data structure called
+`Context`. 
+
+Say we want to sign a new transaction. The Context should be created for each input of the
+transaction and then passed to the Prover which will generate a signature for that input.
+See [general overview of signing and
+verification](https://github.com/ScorexFoundation/sigmastate-interpreter#sigma-language-background)
+process in Ergo for details.
+
+In general, the Context represents the current state of the blockchain and includes
+current header, previous 10 headers, current height etc. This data can be retrieved from
+blockchain nodes. This is possible on Hot Wallet device - a device with a network
+connection, but is not possible on [Cold Wallet](eip-0019.md) device (where there is no
+network connection).
+
+At the same time the prover (which generates a signature for the transaction) need to know
+both the Context data _and_ the private keys, which are stored on the Cold Wallet device,
+and so the Prover must run on the Cold Wallet device.
+
+And that is the problem, we cannot transfer unsigned transaction along with all the
+contexts for each input to the Cold Wallet via QR codes. QR codes have limit of 4K bytes
+on the maximum size of serialized data. Even simplest transactions when serialized with
+required Contexts will exceed this limit.
+
+## Reduced Transaction data
+
+Here we introduce a new data structure and serialization format called
+`ReducedTransaction`.
+
+```
+ReducedTransaction:
+  - unsignedTx: UnsignedTransaction
+  - reducedInputs: Seq[ReducedInputData]
+  - txCost: Int
+
+UnsignedTransaction:
+  - inputs: Seq[UnsignedInput],
+  - dataInputs: Seq[DataInput],
+  - outputCandidates: Seq[ErgoBoxCandidate]
+
+UnsignedInput:
+  - boxId: BoxId
+  - extension: ContextExtension
+
+ReducedInputData:
+- reductionResult: ReductionResult
+
+ReductionResult:
+  - value: SigmaBoolean
+  - cost: Long
+```
+
+Thus, the `ReducedTransaction` instance contains unsigned transaction augmented with
+one `ReductionResult` for each `UnsignedInput`.
+
+Note that `UnsignedInput` object doesn't contain `ergoTree`, `additionalTokens`,
+`additionalRegisters` and other properties of
+[ErgoBox](https://github.com/ScorexFoundation/sigmastate-interpreter/blob/4533b6a7ae86ada20f3136c70a67a920ae7c43e1/sigmastate/src/main/scala/org/ergoplatform/ErgoBox.scala#L51)
+which are necessary to perform
+[ErgoTree](https://github.com/ScorexFoundation/sigmastate-interpreter/blob/1a1b003bc30e490d8b5af30e7670227e54e682c2/sigmastate/src/main/scala/sigmastate/Values.scala#L1014)
+reduction and which are part of the
+[Context](https://github.com/ScorexFoundation/sigmastate-interpreter/blob/e5127f6743db824f7280881cd5c4ecd336075e2f/sigmastate/src/main/scala/org/ergoplatform/ErgoLikeContext.scala#L51)
+data structure required by the
+[prove](https://github.com/ScorexFoundation/sigmastate-interpreter/blob/f24833d8d4572d77e4a93e5b69360335cb2d7dc1/sigmastate/src/main/scala/sigmastate/interpreter/ProverInterpreter.scala#L104)
+method to generate a proof (aka signature).
+
+This is because those context data is not required to generate proof
+once ErgoTree is reduced to ReductionResult containing sigma proposition.
+
+## Data Formats
+
+### ReducedTransaction
+
+ReducedTransaction is serialized to bytes array in the format described below. Note, field
+names are not serialized.
+
+| Field Name      | Format              | Description                                       |
+|-----------------|---------------------|---------------------------------------------------|
+| `messageSize`   | `VLQ(UInt)`         | Number of bytes in the messageToSign of the transaction |
+| `messageToSign` | `Bytes`             | serialized bytes of the unsignedTx.messageToSign  |
+| `reducedInputs` | `ReductionResult*` | serialized reduced inputs                         |
+
+Note, the number of reduced inputs is serialized as part of the `messageToSign`.
+
+### ReductionResult
+
+Reduction result is obtained for each input of the original unsigned transaction.
+
+| Field Name | Format         | Description                                                         |
+|------------|----------------|---------------------------------------------------------------------|
+| `value`    | `SigmaBoolean` | serialized sigma proposition, see section 5.2.2 in [2](#references) |
+| `cost`     | `VLQ(ULong)`   | cost accumulated during reduction of the input's ErgoTree           |
+
+## Implementation in Appkit
+
+ReducedTransaction is represented in Appkit as a
+[class](https://github.com/ergoplatform/ergo-appkit/blob/1d7503595eab13f8762efa36c426ad61dbfd58ce/lib-impl/src/main/java/org/ergoplatform/appkit/impl/ReducedTransactionImpl.java)
+which can be [serialized to bytes array](https://github.com/ergoplatform/ergo-appkit/blob/c89e5e3d82d6e51f206c9415ecfe48d8830540dc/common/src/main/java/org/ergoplatform/appkit/AppkitProvingInterpreter.scala#L342).
+
+## References
+
+1. [EIP-0019: Cold Wallet](eip-0019.md)
+2. [ErgoTree specification](https://ergoplatform.org/docs/ErgoTree.pdf)

--- a/eip-0043.md
+++ b/eip-0043.md
@@ -122,7 +122,7 @@ Reduction result is obtained for each input of the original unsigned transaction
 
 ReducedTransaction is represented in Appkit as a
 [class](https://github.com/ergoplatform/ergo-appkit/blob/1d7503595eab13f8762efa36c426ad61dbfd58ce/lib-impl/src/main/java/org/ergoplatform/appkit/impl/ReducedTransactionImpl.java)
-which can be [serialized to bytes array](https://github.com/ergoplatform/ergo-appkit/blob/c89e5e3d82d6e51f206c9415ecfe48d8830540dc/common/src/main/java/org/ergoplatform/appkit/AppkitProvingInterpreter.scala#L342).
+which can be [serialized to bytes array](https://github.com/ergoplatform/ergo-appkit/blob/8478da6373e7b8138bcda30bbbaafc0f0fe22da6/common/src/main/java/org/ergoplatform/appkit/AppkitProvingInterpreter.scala#L332).
 
 ## References
 


### PR DESCRIPTION
The original text was part of EIP-19. In this PR I moved it into separate EIP. 
Reduced Transactions are now used in ErgoPay and also make sense in other use cases (i.e. API endpoint)

- [x] moved background and motivation section
- [x] moved data structure section
- [x] Added specification of binary format.
