### PR TITLE
EIP-0023. Let ballot token owner (R4 in ballot box) always spend the ballot box

### DIFF
--- a/eip-0023/contracts/ballot_contract.es
+++ b/eip-0023/contracts/ballot_contract.es
@@ -28,6 +28,5 @@
   
   val owner = proveDlog(selfPubKey)
   
-  // unlike in collection, here we don't require spender to be one of the ballot token holders
-  isSimpleCopy && (owner || update)
+  owner || (isSimpleCopy && update)
 }

--- a/eip-0023/eip-0023.md
+++ b/eip-0023/eip-0023.md
@@ -142,7 +142,7 @@ Before going into the transactions in the protocol, we first present the contrac
 - [Pool Contract](contracts/pool_contract.es) `8cJi+FGGU32jXyO8M2LeyWSWlerdcb1zxBWeZtyy7Y8=`
 - [Refresh Contract](contracts/refresh_contract.es) `cs5c5QEirstI4ZlTyrbTjlPwWYHRW+QsedtpyOSBnH4=`
 - [Oracle Contract](contracts/oracle_contract.es) `fhOYLO3s+NJCqTQDWUz0E+ffy2T1VG7ZnhSFs0RP948=`
-- [Ballot Contract](contracts/ballot_contract.es) `2DnK+72bh+TxviNk8XfuYzLKtuF5jnqUJOzimt30NvI=`
+- [Ballot Contract](contracts/ballot_contract.es) `x01xAvK0CrRCwj36vp/jon7NARR1rxplSwI5B20ZNyI=`
 - [Update Contract](contracts/update_contract.es) `pQ7Dgjq1pUyISroP+RWEDf+kVNYAWjeFHzW+cpImhsQ=`
 Use this Scastie playground to calculate the above hashes - [https://scastie.scala-lang.org/hnTEm2lJQPG1wRYCqPz8LQ](https://scastie.scala-lang.org/hnTEm2lJQPG1wRYCqPz8LQ)
 ## Transactions


### PR DESCRIPTION
Following https://github.com/ergoplatform/eips/pull/41/files#r1243427074

## Motivation

`isSimpleCopy` clause for `owner` requires minting new ballot tokens for ANY change to the update contract or its parameters (min_votes). 

I forgot to mint new ballot tokens on changing the update contract and now those ballot tokens cannot be used. See https://github.com/ergoplatform/oracle-core/issues/291#issuecomment-1609089590 for details.

Rewriting the final clause as `owner || (isSimpleCopy && update)` would allow to keep using existing ballot tokens since voting is done by ballot owners (PK check).
