### PR TITLE
EIP-0025: Fixed some errors and grammar, moved some text

### DIFF
--- a/eip-0025.md
+++ b/eip-0025.md
@@ -1,7 +1,7 @@
 EIP-0025: URI scheme for payment requests
 =========================================
 
-* Author: MrStahlfelge
+* Author: MrStahlfelge, Aberg
 * Created: 14-Dec-2021
 * License: CC0
 * Forking: not needed
@@ -21,19 +21,19 @@ so this scheme is easier to handle on static websites or in e-mails.
 Format
 ------
 
-    ergourn        = "ergo:" ergoaddress [ "?" ergoparams ]
-    ergoaddress    = *base58
-    ergoparams     = ergoparam [ "&" ergoparams ]
-    ergoparam      = [ amountparam / labelparam / messageparam / tokenparam ]
-    amountparam    = "amount=" *digit [ "." *digit ]
-    labelparam     = "label=" *qchar
-    messageparam   = "description=" *qchar
-    tokenparam     = "token-" qchar *qchar "=" *digit [ "." *digit ]
+    ergourn            = "ergo:" ergoaddress [ "?" ergoparams ]
+    ergoaddress        = *base58
+    ergoparams         = ergoparam [ "&" ergoparams ]
+    ergoparam          = [ amountparam / labelparam / descriptionparam / tokenparam ]
+    amountparam        = "amount=" *digit [ "." *digit ]
+    labelparam         = "label=" *qchar
+    descriptionparam   = "description=" *qchar
+    tokenparam         = "token-" qchar *qchar "=" *digit [ "." *digit ]
 
 
-* label: Label for that address (e.g. name of receiver)
-* address: ergo P2PK or P2S address
-* description: message that describes the transaction to the user
+* label: Label for that address (e.g. name of recipient). This can be used for when saving to an address book, for example
+* address: Ergo P2PK or P2S address
+* description: Message that describes the transaction to the user
  
 ### Amount
 
@@ -45,24 +45,23 @@ whole numbers and decimal fractions. I.e. amount=50.00 or amount=50 is treated a
 If a token parameter is provided, it specifies the token id and the desired amount separated by an equals sign. The amount must be specified in decimal token 
 value, for example "3.45" for 3.45 SigUSD. The amount MUST contain no commas and use a period (.) as the separating character to separate whole numbers and decimal fractions.
 
+In the case of sending only tokens, a minimum amount of ERGs MUST also be sent to a new box (it is not possible to create boxes containing tokens only with zero ERGs).
+
+The wallet should process the URI as long as it can parse and interpret the content unambiguously. Any ambiguity should be detected and if it cannot be resolved, the wallet should give a descriptive message to the user (not just "Invalid URI", but what exactly has been detected as invalid).
+
+At the same time the wallet should not do anything implicitly, even if it is smart enough to so some implicit actions, it should display what is going on to the user on the transaction sending screen. The user should be aware that some implicit actions were taken by wallet and that those actions will take effect when the transaction is sent.
+
+Applying the above principles to the missing ERGs amount parameter problem we can see that it can be automatically resolved by the wallet, so the wallet shouldn't reject the URI as invalid when the amount of ERGs is missing. At the same time, the screen should have an explanation that non-zero amount of ERGs in the field is required and that it was suggested by the wallet.
+
+For the case of duplicate tokens, the wallet CAN consider such URI as invalid, and clearly communicate the problem to the user so that the user can take a screenshot and send it back to the URI author. The duplication problem should be clear from the screenshot.
 
 Examples
 --------
 
-     ergoplatform:9ewA9T53dy5qvAkcR5jVCtbaDW2XgWzbLPs5H4uCJJavmA4fzDx
+     ergo:9ewA9T53dy5qvAkcR5jVCtbaDW2XgWzbLPs5H4uCJJavmA4fzDx
 
-     ergoplatform:9ewA9T53dy5qvAkcR5jVCtbaDW2XgWzbLPs5H4uCJJavmA4fzDx?amount=1.0&description=Hard%20work
+     ergo:9ewA9T53dy5qvAkcR5jVCtbaDW2XgWzbLPs5H4uCJJavmA4fzDx?amount=1.0&description=Hard%20work
 requests 1 ERG for hard work
 
-     ergoplatform:9ewA9T53dy5qvAkcR5jVCtbaDW2XgWzbLPs5H4uCJJavmA4fzDx?token-03faf2cb329f2e90d6d23b58d91bbb6c046aa143261cc21f52fbe2824bfcbf04=5
+     ergo:9ewA9T53dy5qvAkcR5jVCtbaDW2XgWzbLPs5H4uCJJavmA4fzDx?token-03faf2cb329f2e90d6d23b58d91bbb6c046aa143261cc21f52fbe2824bfcbf04=5
 requests 5 SigUSD
-
-In the case of sending token only, a minimum amount of ERGs MUST also be sent to a new box (it is not possible to create boxes containing tokens only with zero ERGs).
-
-The wallet should process the URI as long as it can parse and interpret the content unambiguously. Any ambiguity should be detected and if it cannot be resolved, the wallet should give a descriptive message to the user (not just "Invalid URI", but what exactly has been detected as invalid).
-
-At the same time the wallet should not do anything implicitly, even if it is smart enough to so some implicit actions, it should display what is going on to the user on the transaction sending screen. The user should be aware that some implicit action where taken by wallet and that those actions will take effect when the Send button is pressed.
-
-Applying the above principles to the missing ERGs amount parameter problem we can see that it can be automatically resolved by the wallet, so the wallet shouldn't reject the URI as invalid when the amount of ERGs is missing. At the same time, the screen should have an explanation that non-zero amount of ERGs in the field is required and that it was suggested by the wallet.
-
-For the case of duplicate tokens, the wallet CAN consider such URI as invalid, and clearly communicate the problem to the user so that the user can take a screenshot and send it back to the dApp developer. The duplication problem should be clear from the screenshot.


### PR DESCRIPTION
- Moved some text about handling tokens under the Tokens heading.
- Fixed examples where an incorrect scheme name was used.
- Fixed grammar of some texts.
- Fixed name of the description parameter in the Format.
- Added an example for what the label can be used for.
- Added myself to authors (the idea was developed jointly)